### PR TITLE
Python client updates, improve testing, include dependencies when installing package

### DIFF
--- a/client_generator/__main__.py
+++ b/client_generator/__main__.py
@@ -3,7 +3,7 @@ import tempfile
 import shutil
 import json
 import urllib.request
-from urllib.error import URLError
+import urllib.error
 
 DOWNLOAD_SPEC_FROM = 'http://localhost:8081/sedaro-satellite.json'
 
@@ -108,7 +108,7 @@ def run_generator(skip_intro=False):
         try:
             urllib.request.urlretrieve(
                 DOWNLOAD_SPEC_FROM, f'{TEMP_SPEC_LOCATION}')
-        except URLError:
+        except urllib.error.URLError:
             print(
                 f'\nError retrieving spec. Please ensure it is available at: "{DOWNLOAD_SPEC_FROM}".\n'
             )

--- a/client_generator/__main__.py
+++ b/client_generator/__main__.py
@@ -1,8 +1,9 @@
 import os
-import urllib.request
 import tempfile
 import shutil
 import json
+import urllib.request
+from urllib.error import URLError
 
 DOWNLOAD_SPEC_FROM = 'http://localhost:8081/sedaro-satellite.json'
 
@@ -104,7 +105,14 @@ def run_generator(skip_intro=False):
             os.system(f'rm -r {CLIENT_DIR}')
 
         TEMP_SPEC_LOCATION = f'{temp_dir}/spec.json'
-        urllib.request.urlretrieve(DOWNLOAD_SPEC_FROM, f'{TEMP_SPEC_LOCATION}')
+        try:
+            urllib.request.urlretrieve(
+                DOWNLOAD_SPEC_FROM, f'{TEMP_SPEC_LOCATION}')
+        except URLError:
+            print(
+                f'\nError retrieving spec. Please ensure it is available at: "{DOWNLOAD_SPEC_FROM}".\n'
+            )
+            return
 
         # ----- generate client -----
         cmd = f'docker run --rm -v "${{PWD}}:/local" openapitools/openapi-generator-cli generate \

--- a/package_managing/readme.md
+++ b/package_managing/readme.md
@@ -6,7 +6,7 @@
 - Use client generator to make sure `sedaro_base_client` is up to date (options > "python" > "mu")
   - Make sure dependencies in `sedaro/src/pyproject.toml` are up to date (should include everything in `requirements.txt` and `requirements-base-client.txt`)
 - Ensure `BlockClassClient` options are up-to-date in `tests/block_class_client_options.py` and in `sedaro/readme.md`
-- Use `python_version_manager` to install local sedaro package and run tests using **dev server** in python 3.7 - 3.10
+- Use `python_version_manager` to install **local sedaro** package and run tests using **dev server** in python 3.7 - 3.10
 - Sync release `version` in `sedaro/src/pyproject.toml` file with Sedaro site release version
 
 ## Build
@@ -23,10 +23,10 @@ Inside `sedaro-python/`:
 
 - `$ python3 -m twine upload --repository testpypi dist/\*`
   - requires username and password
-- Use `python_version_manager` to install sedaro from test.pypi and run tests using **live server** in python 3.7 - 3.10
+- Use `python_version_manager` to install sedaro from **test.pypi** and run tests using **live server** in python 3.7 - 3.10
 
 ## Publish to pypi:
 
 - `$ python -m twine upload dist/\*`
   - requires username and password
-- Use `python_version_manager` to install sedaro from pypi and run tests using **live server** in python 3.7 - 3.10
+- Use `python_version_manager` to install sedaro from **pypi** and run tests using **live server** in python 3.7 - 3.10

--- a/package_managing/readme.md
+++ b/package_managing/readme.md
@@ -1,0 +1,29 @@
+# Publishing to Python Package Index
+
+## Preparation:
+
+- Ensure on most up-to-date `sedaro-app` branch and openapi container is running (check spec at `http://localhost:8081/redoc`)
+- Use client generator to make sure `sedaro_base_client` is up to date (options > "python" > "mu")
+- Ensure `BlockClassClient` options are up-to-date in `tests/block_class_client_options.py` and in `sedaro/readme.md`
+- Use `python_version_manager` to install local sedaro package and run tests using **dev server** in python 3.7 - 3.10
+- Sync release `version` in `sedaro/src/pyproject.toml` file with Sedaro site release version
+
+## Build
+
+Inside `sedaro-python/`:
+
+- Deactivate current python environment (`$ deactivate`)
+- `$ rm -rf .venv && python3 -m venv ./.venv && source .venv/bin/activate && pip install --upgrade pip && pip install --upgrade setuptools build twine`
+- `$ cd sedaro`
+- `$ rm -rf dist && python3 -m build`
+- If doesn’t create `.tar.gz` and `.whl`, wait a minute. Can re-run ^^^ if needed.
+
+## Publish to test.pypi
+
+- `$ python3 -m twine upload --repository testpypi dist/\*`
+- Use `python_version_manager` to install sedaro from test.pypi and run tests using **live server** in python 3.7 - 3.10
+
+## Publish to pypi:
+
+- `$ python -m twine upload dist/\*`
+- Use `python_version_manager` to install sedaro from pypi and run tests using **live server** in python 3.7 - 3.10

--- a/package_managing/readme.md
+++ b/package_managing/readme.md
@@ -4,6 +4,7 @@
 
 - Ensure on most up-to-date `sedaro-app` branch and openapi container is running (check spec at `http://localhost:8081/redoc`)
 - Use client generator to make sure `sedaro_base_client` is up to date (options > "python" > "mu")
+  - Make sure dependencies in `sedaro/src/pyproject.toml` are up to date (should include everything in `requirements.txt` and `requirements-base-client.txt`)
 - Ensure `BlockClassClient` options are up-to-date in `tests/block_class_client_options.py` and in `sedaro/readme.md`
 - Use `python_version_manager` to install local sedaro package and run tests using **dev server** in python 3.7 - 3.10
 - Sync release `version` in `sedaro/src/pyproject.toml` file with Sedaro site release version

--- a/package_managing/readme.md
+++ b/package_managing/readme.md
@@ -21,9 +21,11 @@ Inside `sedaro-python/`:
 ## Publish to test.pypi
 
 - `$ python3 -m twine upload --repository testpypi dist/\*`
+  - requires username and password
 - Use `python_version_manager` to install sedaro from test.pypi and run tests using **live server** in python 3.7 - 3.10
 
 ## Publish to pypi:
 
 - `$ python -m twine upload dist/\*`
+  - requires username and password
 - Use `python_version_manager` to install sedaro from pypi and run tests using **live server** in python 3.7 - 3.10

--- a/python_version_manager/__main__.py
+++ b/python_version_manager/__main__.py
@@ -2,22 +2,32 @@ import os
 import shutil
 
 QUIT = "q"
-SWITCH = "s"
+SWITCH = "sl"
 SWITCH_PYPI = "sp"
+SWITCH_PYPI_TEST = "st"
 RUN_TESTS = 't'
-OPTIONS_MAIN = [QUIT, SWITCH, SWITCH_PYPI]
-# OPTIONS_MAIN = [QUIT, SWITCH, SWITCH_PYPI, RUN_TESTS]
+
+PY_VERSIONS_TESTS = ['3.7', '3.8', '3.9', '3.10']
+
+SWITCH_INSTR = 'Switch python version in venv, install sedaro from: '
+
+OPTIONS_MAIN = {
+    QUIT: 'Quit',
+    SWITCH: f'{SWITCH_INSTR}local sedaro directory',
+    SWITCH_PYPI: f'{SWITCH_INSTR}pypi',
+    SWITCH_PYPI_TEST: f'{SWITCH_INSTR}test.pypi',
+    # RUN_TESTS: f'Run tests in python versions {PY_VERSIONS_TESTS}'
+}
 # TODO: python version wasn't switching in tests, so disabled RUN_TESTS for now
 # Add that option back in and test it then follow the print outputs to see if works
 VENV = '.venv'
-PYTHON_VERSIONS = ['3.7', '3.8', '3.9', '3.10']
 
 
 def get_cur_python_version():
     return os.popen("python3 -V").read().split("Python")[1][1:]
 
 
-def switch_current_python_virtual_environment(new_version=None, run_tests=False, install_pypi_sedaro=False):
+def switch_current_python_virtual_environment(new_version=None, run_tests=False, pypi_sedaro=False, test_pypi_sedaro=False):
     if new_version is None:
         print('\nAvailable python versions:')
         os.system('pyenv versions')
@@ -35,8 +45,10 @@ def switch_current_python_virtual_environment(new_version=None, run_tests=False,
 
     try:
         command = f'pyenv local {new_version} && python3 -m venv ./.venv && source .venv/bin/activate && pip install --upgrade pip'
-        if install_pypi_sedaro:
+        if pypi_sedaro:
             command += ' && pip install sedaro'
+        elif test_pypi_sedaro:
+            command += ' pip install --index-url https://test.pypi.org/simple/ --upgrade --no-cache-dir --extra-index-url=https://pypi.org/simple/ sedaro'
         else:
             command += ' && pip install -e sedaro'
         if run_tests:
@@ -68,22 +80,12 @@ def sedaro_client_python_version_manager():
     how_proceed = ''
     while how_proceed not in OPTIONS_MAIN:
         print('Options:')
-        if QUIT in OPTIONS_MAIN:
-            print(
-                f'  - "{QUIT}"    Quit'
-            )
-        if SWITCH in OPTIONS_MAIN:
-            print(
-                f'  - "{SWITCH}"    Switch python version in venv (deletes current venv if exists) and install sedaro from local sedaro directory'
-            )
-        if SWITCH_PYPI in OPTIONS_MAIN:
-            print(
-                f'  - "{SWITCH_PYPI}"   Switch python version in venv (deletes current venv if exists) and install sedaro from pypi'
-            )
-        if RUN_TESTS in OPTIONS_MAIN:
-            print(
-                f'  - "{RUN_TESTS}"    Run tests in python versions {PYTHON_VERSIONS}'
-            )
+        print('  (note, "Switch" options delete current venv)')
+        for k, v in OPTIONS_MAIN.items():
+            command = f'  - "{k}"'
+            for _ in range(8 - len(k)):
+                command += ' '
+            print(command + v)
 
         how_proceed = input('~ ')
 
@@ -92,22 +94,23 @@ def sedaro_client_python_version_manager():
 
     if how_proceed == QUIT:
         print('\nClosing manager\n')
-        return
 
-    if how_proceed == SWITCH:
+    elif how_proceed == SWITCH:
         switch_current_python_virtual_environment()
-        return
 
-    if how_proceed == SWITCH_PYPI:
-        switch_current_python_virtual_environment(install_pypi_sedaro=True)
-        return
+    elif how_proceed == SWITCH_PYPI:
+        switch_current_python_virtual_environment(pypi_sedaro=True)
 
-    if how_proceed == RUN_TESTS:
-        for version in PYTHON_VERSIONS:
+    elif how_proceed == SWITCH_PYPI_TEST:
+        switch_current_python_virtual_environment(test_pypi_sedaro=True)
+
+    elif how_proceed == RUN_TESTS:
+        for version in PY_VERSIONS_TESTS:
             switch_current_python_virtual_environment(version, run_tests=True)
             print(f'\n🛰️  Finished running tests for version {version}')
-        print(f'\n🛰️  Finished running tests for versions {PYTHON_VERSIONS}')
-        return
+        print(f'\n🛰️  Finished running tests for versions {PY_VERSIONS_TESTS}')
+
+    return
 
 
 if __name__ == '__main__':

--- a/python_version_manager/__main__.py
+++ b/python_version_manager/__main__.py
@@ -3,24 +3,28 @@ import shutil
 import time
 
 QUIT = "q"
-SWITCH = "sl"
-SWITCH_PYPI = "sp"
+SWITCH_LOCAL = "sl"
+TESTS_LOCAL = 'tl'
 SWITCH_PYPI_TEST = "st"
-RUN_TESTS = 't'
+TESTS_PYPI_TEST = 'tt'
+SWITCH_PYPI = "sp"
+TESTS_PYPI = 'tp'
 
 PY_VERSIONS_TESTS = ['3.7', '3.8', '3.9', '3.10']
 
 SWITCH_INSTR = 'Switch python version, install sedaro from: '
+TEST_INSTR = f'Run tests in python versions {PY_VERSIONS_TESTS} using sedaro from: '
 
 OPTIONS_MAIN = {
     QUIT: 'Quit',
-    SWITCH: f'{SWITCH_INSTR}local sedaro directory',
-    SWITCH_PYPI: f'{SWITCH_INSTR}pypi',
+    SWITCH_LOCAL: f'{SWITCH_INSTR}local sedaro directory',
+    TESTS_LOCAL: f'{TEST_INSTR}local sedaro directory',
     SWITCH_PYPI_TEST: f'{SWITCH_INSTR}test.pypi',
-    RUN_TESTS: f'Run tests in python versions {PY_VERSIONS_TESTS}'
+    TESTS_PYPI_TEST: f'{TEST_INSTR}test.pypi',
+    SWITCH_PYPI: f'{SWITCH_INSTR}pypi',
+    TESTS_PYPI: f'{TEST_INSTR}pypi',
 }
-# TODO: python version wasn't switching in tests, so disabled RUN_TESTS for now
-# Add that option back in and test it then follow the print outputs to see if works
+
 VENV = '.venv'
 
 
@@ -42,12 +46,15 @@ def switch_current_python_virtual_environment(new_version=None, run_tests=False,
 
     print_msg = f'\n🛰️  Creating virtual environment for Python {new_version} and installing sedaro'
     if pypi_sedaro:
-        print_msg += ' from pypi'
+        print_msg_end = 'from pypi'
     elif test_pypi_sedaro:
-        print_msg += ' from test.pypi'
+        print_msg_end = 'from test.pypi'
     else:
-        print_msg += ' from local sedaro directory'
-    print(print_msg + '...\n')
+        print_msg_end = 'from local sedaro directory'
+
+    print(
+        f'\n🛰️  Creating virtual environment for Python {new_version} and installing sedaro {print_msg_end}...\n'
+    )
 
     try:
         command = f'pyenv local {new_version} && python3 -m venv ./.venv && source .venv/bin/activate && pip install --upgrade pip && pip install -U autopep8'
@@ -60,7 +67,7 @@ def switch_current_python_virtual_environment(new_version=None, run_tests=False,
             command += ' && pip install -e sedaro'
         os.system(command)
         print(
-            f'\n🛰️  Virtual environment created/activated with Python {new_version} and sedaro installed'
+            f'\n🛰️  Virtual environment created/activated with Python {new_version} and sedaro installed {print_msg_end}'
         )
         if run_tests:
             os.system('python3 tests')
@@ -99,27 +106,30 @@ def sedaro_client_python_version_manager():
         if how_proceed not in OPTIONS_MAIN:
             print(f'\nInvalid option: "{how_proceed}"\n')
 
+    kwargs = {}
+
     if how_proceed == QUIT:
         print('\nClosing manager\n')
+    elif how_proceed in [SWITCH_PYPI, TESTS_PYPI]:
+        kwargs['pypi_sedaro'] = True
+    elif how_proceed in [SWITCH_PYPI_TEST, TESTS_PYPI_TEST]:
+        kwargs['test_pypi_sedaro'] = True
 
-    elif how_proceed == SWITCH:
-        switch_current_python_virtual_environment()
+    # just switch or switch and run tests
+    if how_proceed in [SWITCH_LOCAL, SWITCH_PYPI, SWITCH_PYPI_TEST]:
+        switch_current_python_virtual_environment(**kwargs)
 
-    elif how_proceed == SWITCH_PYPI:
-        switch_current_python_virtual_environment(pypi_sedaro=True)
-
-    elif how_proceed == SWITCH_PYPI_TEST:
-        switch_current_python_virtual_environment(test_pypi_sedaro=True)
-
-    elif how_proceed == RUN_TESTS:
+    elif how_proceed in [TESTS_LOCAL, TESTS_PYPI, TESTS_PYPI_TEST]:
         for version in PY_VERSIONS_TESTS:
             switch_current_python_virtual_environment(
                 new_version=version,
-                run_tests=True
+                run_tests=True,
+                **kwargs
             )
             print(f'\n🛰️  Finished running tests for version {version}')
             # short pause needed here to make sure next venv is created and used properly
             time.sleep(1)
+
         print(f'\n🛰️  Finished running tests for versions {PY_VERSIONS_TESTS}')
 
     return

--- a/python_version_manager/__main__.py
+++ b/python_version_manager/__main__.py
@@ -34,7 +34,7 @@ def switch_current_python_virtual_environment(new_version=None, run_tests=False,
     )
 
     try:
-        command = f'pyenv local {new_version} && python3 -m venv ./.venv && source .venv/bin/activate'
+        command = f'pyenv local {new_version} && python3 -m venv ./.venv && source .venv/bin/activate && pip install --upgrade pip'
         if install_pypi_sedaro:
             command += ' && pip install sedaro'
         else:

--- a/python_version_manager/__main__.py
+++ b/python_version_manager/__main__.py
@@ -107,7 +107,10 @@ def sedaro_client_python_version_manager():
 
     elif how_proceed == RUN_TESTS:
         for version in PY_VERSIONS_TESTS:
-            switch_current_python_virtual_environment(version, run_tests=True)
+            switch_current_python_virtual_environment(
+                new_version=version,
+                run_tests=True
+            )
             print(f'\n🛰️  Finished running tests for version {version}')
         print(f'\n🛰️  Finished running tests for versions {PY_VERSIONS_TESTS}')
 

--- a/python_version_manager/__main__.py
+++ b/python_version_manager/__main__.py
@@ -3,9 +3,10 @@ import shutil
 
 QUIT = "q"
 SWITCH = "s"
+SWITCH_PYPI = "sp"
 RUN_TESTS = 't'
-OPTIONS_MAIN = [QUIT, SWITCH]
-# OPTIONS_MAIN = [QUIT, SWITCH, RUN_TESTS]
+OPTIONS_MAIN = [QUIT, SWITCH, SWITCH_PYPI]
+# OPTIONS_MAIN = [QUIT, SWITCH, SWITCH_PYPI, RUN_TESTS]
 # TODO: python version wasn't switching in tests, so disabled RUN_TESTS for now
 # Add that option back in and test it then follow the print outputs to see if works
 VENV = '.venv'
@@ -16,7 +17,7 @@ def get_cur_python_version():
     return os.popen("python3 -V").read().split("Python")[1][1:]
 
 
-def switch_current_python_virtual_environment(new_version=None, run_tests=False):
+def switch_current_python_virtual_environment(new_version=None, run_tests=False, install_pypi_sedaro=False):
     if new_version is None:
         print('\nAvailable python versions:')
         os.system('pyenv versions')
@@ -33,7 +34,11 @@ def switch_current_python_virtual_environment(new_version=None, run_tests=False)
     )
 
     try:
-        command = f'pyenv local {new_version} && python3 -m venv ./.venv && source .venv/bin/activate && pip install -e sedaro'
+        command = f'pyenv local {new_version} && python3 -m venv ./.venv && source .venv/bin/activate'
+        if install_pypi_sedaro:
+            command += ' && pip install sedaro'
+        else:
+            command += ' && pip install -e sedaro'
         if run_tests:
             command += ' && python3 tests'
         os.system(command)
@@ -65,15 +70,19 @@ def sedaro_client_python_version_manager():
         print('Options:')
         if QUIT in OPTIONS_MAIN:
             print(
-                f'  - "{QUIT}"   Quit'
+                f'  - "{QUIT}"    Quit'
             )
         if SWITCH in OPTIONS_MAIN:
             print(
-                f'  - "{SWITCH}"   Switch to a new python virtual environment (deletes current one if exists)'
+                f'  - "{SWITCH}"    Switch python version in venv (deletes current venv if exists) and install sedaro from local sedaro directory'
+            )
+        if SWITCH_PYPI in OPTIONS_MAIN:
+            print(
+                f'  - "{SWITCH_PYPI}"   Switch python version in venv (deletes current venv if exists) and install sedaro from pypi'
             )
         if RUN_TESTS in OPTIONS_MAIN:
             print(
-                f'  - "{RUN_TESTS}"   Run tests in python versions {PYTHON_VERSIONS}'
+                f'  - "{RUN_TESTS}"    Run tests in python versions {PYTHON_VERSIONS}'
             )
 
         how_proceed = input('~ ')
@@ -87,6 +96,10 @@ def sedaro_client_python_version_manager():
 
     if how_proceed == SWITCH:
         switch_current_python_virtual_environment()
+        return
+
+    if how_proceed == SWITCH_PYPI:
+        switch_current_python_virtual_environment(install_pypi_sedaro=True)
         return
 
     if how_proceed == RUN_TESTS:

--- a/python_version_manager/__main__.py
+++ b/python_version_manager/__main__.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import time
 
 QUIT = "q"
 SWITCH = "sl"
@@ -16,7 +17,7 @@ OPTIONS_MAIN = {
     SWITCH: f'{SWITCH_INSTR}local sedaro directory',
     SWITCH_PYPI: f'{SWITCH_INSTR}pypi',
     SWITCH_PYPI_TEST: f'{SWITCH_INSTR}test.pypi',
-    # RUN_TESTS: f'Run tests in python versions {PY_VERSIONS_TESTS}'
+    RUN_TESTS: f'Run tests in python versions {PY_VERSIONS_TESTS}'
 }
 # TODO: python version wasn't switching in tests, so disabled RUN_TESTS for now
 # Add that option back in and test it then follow the print outputs to see if works
@@ -39,9 +40,14 @@ def switch_current_python_virtual_environment(new_version=None, run_tests=False,
     if os.path.isdir(VENV):
         shutil.rmtree(VENV)
 
-    print(
-        f'\n🛰️  Creating virtual environment for Python {new_version} and installing sedaro...\n'
-    )
+    print_msg = f'\n🛰️  Creating virtual environment for Python {new_version} and installing sedaro'
+    if pypi_sedaro:
+        print_msg += ' from pypi'
+    elif test_pypi_sedaro:
+        print_msg += ' from test.pypi'
+    else:
+        print_msg += ' from local sedaro directory'
+    print(print_msg + '...\n')
 
     try:
         command = f'pyenv local {new_version} && python3 -m venv ./.venv && source .venv/bin/activate && pip install --upgrade pip && pip install -U autopep8'
@@ -52,12 +58,12 @@ def switch_current_python_virtual_environment(new_version=None, run_tests=False,
             command += ' pip install --index-url https://test.pypi.org/simple/ --upgrade --no-cache-dir --extra-index-url=https://pypi.org/simple/ sedaro'
         else:
             command += ' && pip install -e sedaro'
-        if run_tests:
-            command += ' && python3 tests'
         os.system(command)
         print(
             f'\n🛰️  Virtual environment created/activated with Python {new_version} and sedaro installed'
         )
+        if run_tests:
+            os.system('python3 tests')
 
     except Exception as e:
         print('')
@@ -112,6 +118,8 @@ def sedaro_client_python_version_manager():
                 run_tests=True
             )
             print(f'\n🛰️  Finished running tests for version {version}')
+            # short pause needed here to make sure next venv is created and used properly
+            time.sleep(1)
         print(f'\n🛰️  Finished running tests for versions {PY_VERSIONS_TESTS}')
 
     return

--- a/python_version_manager/__main__.py
+++ b/python_version_manager/__main__.py
@@ -2,12 +2,12 @@ import os
 import shutil
 import time
 
-QUIT = "q"
-SWITCH_LOCAL = "sl"
+QUIT = 'q'
+SWITCH_LOCAL = 'sl'
 TESTS_LOCAL = 'tl'
-SWITCH_PYPI_TEST = "st"
+SWITCH_PYPI_TEST = 'st'
 TESTS_PYPI_TEST = 'tt'
-SWITCH_PYPI = "sp"
+SWITCH_PYPI = 'sp'
 TESTS_PYPI = 'tp'
 
 PY_VERSIONS_TESTS = ['3.7', '3.8', '3.9', '3.10']
@@ -29,7 +29,7 @@ VENV = '.venv'
 
 
 def get_cur_python_version():
-    return os.popen("python3 -V").read().split("Python")[1][1:]
+    return os.popen('python3 -V').read().split('Python')[1][1:]
 
 
 def switch_current_python_virtual_environment(new_version=None, run_tests=False, pypi_sedaro=False, test_pypi_sedaro=False):

--- a/python_version_manager/__main__.py
+++ b/python_version_manager/__main__.py
@@ -9,7 +9,7 @@ RUN_TESTS = 't'
 
 PY_VERSIONS_TESTS = ['3.7', '3.8', '3.9', '3.10']
 
-SWITCH_INSTR = 'Switch python version in venv, install sedaro from: '
+SWITCH_INSTR = 'Switch python version, install sedaro from: '
 
 OPTIONS_MAIN = {
     QUIT: 'Quit',
@@ -44,7 +44,7 @@ def switch_current_python_virtual_environment(new_version=None, run_tests=False,
     )
 
     try:
-        command = f'pyenv local {new_version} && python3 -m venv ./.venv && source .venv/bin/activate && pip install --upgrade pip'
+        command = f'pyenv local {new_version} && python3 -m venv ./.venv && source .venv/bin/activate && pip install --upgrade pip && pip install -U autopep8'
         if pypi_sedaro:
             command += ' && pip install sedaro'
         elif test_pypi_sedaro:
@@ -80,7 +80,7 @@ def sedaro_client_python_version_manager():
     how_proceed = ''
     while how_proceed not in OPTIONS_MAIN:
         print('Options:')
-        print('  (note, "Switch" options delete current venv)')
+        print('  (note, "Switch" options deletes/recreates venv)')
         for k, v in OPTIONS_MAIN.items():
             command = f'  - "{k}"'
             for _ in range(8 - len(k)):

--- a/python_version_manager/__main__.py
+++ b/python_version_manager/__main__.py
@@ -48,6 +48,7 @@ def switch_current_python_virtual_environment(new_version=None, run_tests=False,
         if pypi_sedaro:
             command += ' && pip install sedaro'
         elif test_pypi_sedaro:
+            # see S.O. answer for context on command below: https://stackoverflow.com/a/59495166/16448566
             command += ' pip install --index-url https://test.pypi.org/simple/ --upgrade --no-cache-dir --extra-index-url=https://pypi.org/simple/ sedaro'
         else:
             command += ' && pip install -e sedaro'

--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
 
 # [tool.setuptools.dynamic]
 # dependencies = {file = ["requirements.txt", "requirements-base-client.txt"]}
-# NOTE: Make sure dependencies vvv includes everything from ^^^
+# NOTE: Make sure dependencies (below) includes everything from ^^^ (requirements files)
+# Dependencies weren't being installed when downloading package, so explicitly defined them.
 dependencies = [
     "certifi >= 14.5.14",
     "frozendict ~= 2.3.4",

--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 # [tool.setuptools.dynamic]
 # dependencies = {file = ["requirements.txt", "requirements-base-client.txt"]}
-
+# NOTE: Make sure dependencies vvv includes everything from ^^^
 dependencies = [
     "certifi >= 14.5.14",
     "frozendict ~= 2.3.4",

--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sedaro"
-version = "1.1.1"
+version = "3.2.12"
 authors = [
   { name="Sedaro", email="support@sedarotech.com" },
 ]

--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sedaro"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
   { name="Sedaro", email="support@sedarotech.com" },
 ]

--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -17,10 +17,22 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Software Development",
 ]
-dynamic = ["dependencies"]
 
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt", "requirements-base-client.txt"]}
+# dynamic = ["dependencies"]
+
+# [tool.setuptools.dynamic]
+# dependencies = {file = ["requirements.txt", "requirements-base-client.txt"]}
+
+dependencies = [
+    "certifi >= 14.5.14",
+    "frozendict ~= 2.3.4",
+    "python-dateutil ~= 2.7.0",
+    "setuptools >= 21.0.0",
+    "typing_extensions ~= 4.3.0",
+    "urllib3 ~= 1.26.7",
+    "pydash >= 5.1.1",
+]
+
 
 [project.urls]
 "Homepage" = "https://github.com/sedaro/sedaro-python"

--- a/sedaro/src/sedaro_base_client/model/thermal_interface.py
+++ b/sedaro/src/sedaro_base_client/model/thermal_interface.py
@@ -35,24 +35,13 @@ class ThermalInterface(
 
     class MetaOapg:
         required = {
-            "area",
-            "material",
             "name",
             "sideB",
             "sideA",
         }
         
         class properties:
-            
-            
-            class name(
-                schemas.StrSchema
-            ):
-            
-            
-                class MetaOapg:
-                    max_length = 100
-            area = schemas.NumberSchema
+            name = schemas.StrSchema
             
             
             class sideA(
@@ -125,8 +114,9 @@ class ThermalInterface(
                         _configuration=_configuration,
                         **kwargs,
                     )
-            material = schemas.StrSchema
             id = schemas.StrSchema
+            area = schemas.NumberSchema
+            material = schemas.StrSchema
             componentA = schemas.StrSchema
             componentB = schemas.StrSchema
             surfaceA = schemas.StrSchema
@@ -143,11 +133,11 @@ class ThermalInterface(
             coldMargin = schemas.NumberSchema
             __annotations__ = {
                 "name": name,
-                "area": area,
                 "sideA": sideA,
                 "sideB": sideB,
-                "material": material,
                 "id": id,
+                "area": area,
+                "material": material,
                 "componentA": componentA,
                 "componentB": componentB,
                 "surfaceA": surfaceA,
@@ -164,8 +154,6 @@ class ThermalInterface(
                 "coldMargin": coldMargin,
             }
     
-    area: MetaOapg.properties.area
-    material: MetaOapg.properties.material
     name: MetaOapg.properties.name
     sideB: MetaOapg.properties.sideB
     sideA: MetaOapg.properties.sideA
@@ -174,19 +162,19 @@ class ThermalInterface(
     def __getitem__(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
     
     @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
+    def __getitem__(self, name: typing_extensions.Literal["id"]) -> MetaOapg.properties.id: ...
     
     @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["id"]) -> MetaOapg.properties.id: ...
+    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
+    
+    @typing.overload
+    def __getitem__(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["componentA"]) -> MetaOapg.properties.componentA: ...
@@ -233,7 +221,7 @@ class ThermalInterface(
     @typing.overload
     def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
     
-    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "id", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", "satellite", "resistance", "tempDelta", "heatFlowRate", "hotTemp", "coldTemp", "hotMargin", "coldMargin", ], str]):
+    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "id", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", "satellite", "resistance", "tempDelta", "heatFlowRate", "hotTemp", "coldTemp", "hotMargin", "coldMargin", ], str]):
         # dict_instance[name] accessor
         return super().__getitem__(name)
     
@@ -242,19 +230,19 @@ class ThermalInterface(
     def get_item_oapg(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
+    def get_item_oapg(self, name: typing_extensions.Literal["id"]) -> typing.Union[MetaOapg.properties.id, schemas.Unset]: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["id"]) -> typing.Union[MetaOapg.properties.id, schemas.Unset]: ...
+    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> typing.Union[MetaOapg.properties.area, schemas.Unset]: ...
+    
+    @typing.overload
+    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> typing.Union[MetaOapg.properties.material, schemas.Unset]: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["componentA"]) -> typing.Union[MetaOapg.properties.componentA, schemas.Unset]: ...
@@ -301,19 +289,19 @@ class ThermalInterface(
     @typing.overload
     def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
     
-    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "id", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", "satellite", "resistance", "tempDelta", "heatFlowRate", "hotTemp", "coldTemp", "hotMargin", "coldMargin", ], str]):
+    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "id", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", "satellite", "resistance", "tempDelta", "heatFlowRate", "hotTemp", "coldTemp", "hotMargin", "coldMargin", ], str]):
         return super().get_item_oapg(name)
     
 
     def __new__(
         cls,
         *_args: typing.Union[dict, frozendict.frozendict, ],
-        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, ],
-        material: typing.Union[MetaOapg.properties.material, str, ],
         name: typing.Union[MetaOapg.properties.name, str, ],
         sideB: typing.Union[MetaOapg.properties.sideB, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
         sideA: typing.Union[MetaOapg.properties.sideA, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
         id: typing.Union[MetaOapg.properties.id, str, schemas.Unset] = schemas.unset,
+        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, schemas.Unset] = schemas.unset,
+        material: typing.Union[MetaOapg.properties.material, str, schemas.Unset] = schemas.unset,
         componentA: typing.Union[MetaOapg.properties.componentA, str, schemas.Unset] = schemas.unset,
         componentB: typing.Union[MetaOapg.properties.componentB, str, schemas.Unset] = schemas.unset,
         surfaceA: typing.Union[MetaOapg.properties.surfaceA, str, schemas.Unset] = schemas.unset,
@@ -334,12 +322,12 @@ class ThermalInterface(
         return super().__new__(
             cls,
             *_args,
-            area=area,
-            material=material,
             name=name,
             sideB=sideB,
             sideA=sideA,
             id=id,
+            area=area,
+            material=material,
             componentA=componentA,
             componentB=componentB,
             surfaceA=surfaceA,

--- a/sedaro/src/sedaro_base_client/model/thermal_interface.pyi
+++ b/sedaro/src/sedaro_base_client/model/thermal_interface.pyi
@@ -35,21 +35,13 @@ class ThermalInterface(
 
     class MetaOapg:
         required = {
-            "area",
-            "material",
             "name",
             "sideB",
             "sideA",
         }
         
         class properties:
-            
-            
-            class name(
-                schemas.StrSchema
-            ):
-                pass
-            area = schemas.NumberSchema
+            name = schemas.StrSchema
             
             
             class sideA(
@@ -122,8 +114,9 @@ class ThermalInterface(
                         _configuration=_configuration,
                         **kwargs,
                     )
-            material = schemas.StrSchema
             id = schemas.StrSchema
+            area = schemas.NumberSchema
+            material = schemas.StrSchema
             componentA = schemas.StrSchema
             componentB = schemas.StrSchema
             surfaceA = schemas.StrSchema
@@ -140,11 +133,11 @@ class ThermalInterface(
             coldMargin = schemas.NumberSchema
             __annotations__ = {
                 "name": name,
-                "area": area,
                 "sideA": sideA,
                 "sideB": sideB,
-                "material": material,
                 "id": id,
+                "area": area,
+                "material": material,
                 "componentA": componentA,
                 "componentB": componentB,
                 "surfaceA": surfaceA,
@@ -161,8 +154,6 @@ class ThermalInterface(
                 "coldMargin": coldMargin,
             }
     
-    area: MetaOapg.properties.area
-    material: MetaOapg.properties.material
     name: MetaOapg.properties.name
     sideB: MetaOapg.properties.sideB
     sideA: MetaOapg.properties.sideA
@@ -171,19 +162,19 @@ class ThermalInterface(
     def __getitem__(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
     
     @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
+    def __getitem__(self, name: typing_extensions.Literal["id"]) -> MetaOapg.properties.id: ...
     
     @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["id"]) -> MetaOapg.properties.id: ...
+    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
+    
+    @typing.overload
+    def __getitem__(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["componentA"]) -> MetaOapg.properties.componentA: ...
@@ -230,7 +221,7 @@ class ThermalInterface(
     @typing.overload
     def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
     
-    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "id", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", "satellite", "resistance", "tempDelta", "heatFlowRate", "hotTemp", "coldTemp", "hotMargin", "coldMargin", ], str]):
+    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "id", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", "satellite", "resistance", "tempDelta", "heatFlowRate", "hotTemp", "coldTemp", "hotMargin", "coldMargin", ], str]):
         # dict_instance[name] accessor
         return super().__getitem__(name)
     
@@ -239,19 +230,19 @@ class ThermalInterface(
     def get_item_oapg(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
+    def get_item_oapg(self, name: typing_extensions.Literal["id"]) -> typing.Union[MetaOapg.properties.id, schemas.Unset]: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["id"]) -> typing.Union[MetaOapg.properties.id, schemas.Unset]: ...
+    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> typing.Union[MetaOapg.properties.area, schemas.Unset]: ...
+    
+    @typing.overload
+    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> typing.Union[MetaOapg.properties.material, schemas.Unset]: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["componentA"]) -> typing.Union[MetaOapg.properties.componentA, schemas.Unset]: ...
@@ -298,19 +289,19 @@ class ThermalInterface(
     @typing.overload
     def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
     
-    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "id", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", "satellite", "resistance", "tempDelta", "heatFlowRate", "hotTemp", "coldTemp", "hotMargin", "coldMargin", ], str]):
+    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "id", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", "satellite", "resistance", "tempDelta", "heatFlowRate", "hotTemp", "coldTemp", "hotMargin", "coldMargin", ], str]):
         return super().get_item_oapg(name)
     
 
     def __new__(
         cls,
         *_args: typing.Union[dict, frozendict.frozendict, ],
-        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, ],
-        material: typing.Union[MetaOapg.properties.material, str, ],
         name: typing.Union[MetaOapg.properties.name, str, ],
         sideB: typing.Union[MetaOapg.properties.sideB, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
         sideA: typing.Union[MetaOapg.properties.sideA, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
         id: typing.Union[MetaOapg.properties.id, str, schemas.Unset] = schemas.unset,
+        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, schemas.Unset] = schemas.unset,
+        material: typing.Union[MetaOapg.properties.material, str, schemas.Unset] = schemas.unset,
         componentA: typing.Union[MetaOapg.properties.componentA, str, schemas.Unset] = schemas.unset,
         componentB: typing.Union[MetaOapg.properties.componentB, str, schemas.Unset] = schemas.unset,
         surfaceA: typing.Union[MetaOapg.properties.surfaceA, str, schemas.Unset] = schemas.unset,
@@ -331,12 +322,12 @@ class ThermalInterface(
         return super().__new__(
             cls,
             *_args,
-            area=area,
-            material=material,
             name=name,
             sideB=sideB,
             sideA=sideA,
             id=id,
+            area=area,
+            material=material,
             componentA=componentA,
             componentB=componentB,
             surfaceA=surfaceA,

--- a/sedaro/src/sedaro_base_client/model/thermal_interface_create.py
+++ b/sedaro/src/sedaro_base_client/model/thermal_interface_create.py
@@ -35,24 +35,13 @@ class ThermalInterfaceCreate(
 
     class MetaOapg:
         required = {
-            "area",
-            "material",
             "name",
             "sideB",
             "sideA",
         }
         
         class properties:
-            
-            
-            class name(
-                schemas.StrSchema
-            ):
-            
-            
-                class MetaOapg:
-                    max_length = 100
-            area = schemas.NumberSchema
+            name = schemas.StrSchema
             
             
             class sideA(
@@ -125,6 +114,7 @@ class ThermalInterfaceCreate(
                         _configuration=_configuration,
                         **kwargs,
                     )
+            area = schemas.NumberSchema
             material = schemas.StrSchema
             componentA = schemas.StrSchema
             componentB = schemas.StrSchema
@@ -134,9 +124,9 @@ class ThermalInterfaceCreate(
             coolerB = schemas.StrSchema
             __annotations__ = {
                 "name": name,
-                "area": area,
                 "sideA": sideA,
                 "sideB": sideB,
+                "area": area,
                 "material": material,
                 "componentA": componentA,
                 "componentB": componentB,
@@ -146,8 +136,6 @@ class ThermalInterfaceCreate(
                 "coolerB": coolerB,
             }
     
-    area: MetaOapg.properties.area
-    material: MetaOapg.properties.material
     name: MetaOapg.properties.name
     sideB: MetaOapg.properties.sideB
     sideA: MetaOapg.properties.sideA
@@ -156,13 +144,13 @@ class ThermalInterfaceCreate(
     def __getitem__(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
+    
+    @typing.overload
+    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
@@ -188,7 +176,7 @@ class ThermalInterfaceCreate(
     @typing.overload
     def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
     
-    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
+    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
         # dict_instance[name] accessor
         return super().__getitem__(name)
     
@@ -197,16 +185,16 @@ class ThermalInterfaceCreate(
     def get_item_oapg(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
+    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> typing.Union[MetaOapg.properties.area, schemas.Unset]: ...
+    
+    @typing.overload
+    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> typing.Union[MetaOapg.properties.material, schemas.Unset]: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["componentA"]) -> typing.Union[MetaOapg.properties.componentA, schemas.Unset]: ...
@@ -229,18 +217,18 @@ class ThermalInterfaceCreate(
     @typing.overload
     def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
     
-    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
+    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
         return super().get_item_oapg(name)
     
 
     def __new__(
         cls,
         *_args: typing.Union[dict, frozendict.frozendict, ],
-        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, ],
-        material: typing.Union[MetaOapg.properties.material, str, ],
         name: typing.Union[MetaOapg.properties.name, str, ],
         sideB: typing.Union[MetaOapg.properties.sideB, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
         sideA: typing.Union[MetaOapg.properties.sideA, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
+        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, schemas.Unset] = schemas.unset,
+        material: typing.Union[MetaOapg.properties.material, str, schemas.Unset] = schemas.unset,
         componentA: typing.Union[MetaOapg.properties.componentA, str, schemas.Unset] = schemas.unset,
         componentB: typing.Union[MetaOapg.properties.componentB, str, schemas.Unset] = schemas.unset,
         surfaceA: typing.Union[MetaOapg.properties.surfaceA, str, schemas.Unset] = schemas.unset,
@@ -253,11 +241,11 @@ class ThermalInterfaceCreate(
         return super().__new__(
             cls,
             *_args,
-            area=area,
-            material=material,
             name=name,
             sideB=sideB,
             sideA=sideA,
+            area=area,
+            material=material,
             componentA=componentA,
             componentB=componentB,
             surfaceA=surfaceA,

--- a/sedaro/src/sedaro_base_client/model/thermal_interface_create.pyi
+++ b/sedaro/src/sedaro_base_client/model/thermal_interface_create.pyi
@@ -35,21 +35,13 @@ class ThermalInterfaceCreate(
 
     class MetaOapg:
         required = {
-            "area",
-            "material",
             "name",
             "sideB",
             "sideA",
         }
         
         class properties:
-            
-            
-            class name(
-                schemas.StrSchema
-            ):
-                pass
-            area = schemas.NumberSchema
+            name = schemas.StrSchema
             
             
             class sideA(
@@ -122,6 +114,7 @@ class ThermalInterfaceCreate(
                         _configuration=_configuration,
                         **kwargs,
                     )
+            area = schemas.NumberSchema
             material = schemas.StrSchema
             componentA = schemas.StrSchema
             componentB = schemas.StrSchema
@@ -131,9 +124,9 @@ class ThermalInterfaceCreate(
             coolerB = schemas.StrSchema
             __annotations__ = {
                 "name": name,
-                "area": area,
                 "sideA": sideA,
                 "sideB": sideB,
+                "area": area,
                 "material": material,
                 "componentA": componentA,
                 "componentB": componentB,
@@ -143,8 +136,6 @@ class ThermalInterfaceCreate(
                 "coolerB": coolerB,
             }
     
-    area: MetaOapg.properties.area
-    material: MetaOapg.properties.material
     name: MetaOapg.properties.name
     sideB: MetaOapg.properties.sideB
     sideA: MetaOapg.properties.sideA
@@ -153,13 +144,13 @@ class ThermalInterfaceCreate(
     def __getitem__(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
+    
+    @typing.overload
+    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
@@ -185,7 +176,7 @@ class ThermalInterfaceCreate(
     @typing.overload
     def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
     
-    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
+    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
         # dict_instance[name] accessor
         return super().__getitem__(name)
     
@@ -194,16 +185,16 @@ class ThermalInterfaceCreate(
     def get_item_oapg(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
+    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> typing.Union[MetaOapg.properties.area, schemas.Unset]: ...
+    
+    @typing.overload
+    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> typing.Union[MetaOapg.properties.material, schemas.Unset]: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["componentA"]) -> typing.Union[MetaOapg.properties.componentA, schemas.Unset]: ...
@@ -226,18 +217,18 @@ class ThermalInterfaceCreate(
     @typing.overload
     def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
     
-    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
+    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
         return super().get_item_oapg(name)
     
 
     def __new__(
         cls,
         *_args: typing.Union[dict, frozendict.frozendict, ],
-        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, ],
-        material: typing.Union[MetaOapg.properties.material, str, ],
         name: typing.Union[MetaOapg.properties.name, str, ],
         sideB: typing.Union[MetaOapg.properties.sideB, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
         sideA: typing.Union[MetaOapg.properties.sideA, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
+        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, schemas.Unset] = schemas.unset,
+        material: typing.Union[MetaOapg.properties.material, str, schemas.Unset] = schemas.unset,
         componentA: typing.Union[MetaOapg.properties.componentA, str, schemas.Unset] = schemas.unset,
         componentB: typing.Union[MetaOapg.properties.componentB, str, schemas.Unset] = schemas.unset,
         surfaceA: typing.Union[MetaOapg.properties.surfaceA, str, schemas.Unset] = schemas.unset,
@@ -250,11 +241,11 @@ class ThermalInterfaceCreate(
         return super().__new__(
             cls,
             *_args,
-            area=area,
-            material=material,
             name=name,
             sideB=sideB,
             sideA=sideA,
+            area=area,
+            material=material,
             componentA=componentA,
             componentB=componentB,
             surfaceA=surfaceA,

--- a/sedaro/src/sedaro_base_client/model/thermal_interface_update.py
+++ b/sedaro/src/sedaro_base_client/model/thermal_interface_update.py
@@ -35,24 +35,13 @@ class ThermalInterfaceUpdate(
 
     class MetaOapg:
         required = {
-            "area",
-            "material",
             "name",
             "sideB",
             "sideA",
         }
         
         class properties:
-            
-            
-            class name(
-                schemas.StrSchema
-            ):
-            
-            
-                class MetaOapg:
-                    max_length = 100
-            area = schemas.NumberSchema
+            name = schemas.StrSchema
             
             
             class sideA(
@@ -125,6 +114,7 @@ class ThermalInterfaceUpdate(
                         _configuration=_configuration,
                         **kwargs,
                     )
+            area = schemas.NumberSchema
             material = schemas.StrSchema
             componentA = schemas.StrSchema
             componentB = schemas.StrSchema
@@ -134,9 +124,9 @@ class ThermalInterfaceUpdate(
             coolerB = schemas.StrSchema
             __annotations__ = {
                 "name": name,
-                "area": area,
                 "sideA": sideA,
                 "sideB": sideB,
+                "area": area,
                 "material": material,
                 "componentA": componentA,
                 "componentB": componentB,
@@ -146,8 +136,6 @@ class ThermalInterfaceUpdate(
                 "coolerB": coolerB,
             }
     
-    area: MetaOapg.properties.area
-    material: MetaOapg.properties.material
     name: MetaOapg.properties.name
     sideB: MetaOapg.properties.sideB
     sideA: MetaOapg.properties.sideA
@@ -156,13 +144,13 @@ class ThermalInterfaceUpdate(
     def __getitem__(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
+    
+    @typing.overload
+    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
@@ -188,7 +176,7 @@ class ThermalInterfaceUpdate(
     @typing.overload
     def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
     
-    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
+    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
         # dict_instance[name] accessor
         return super().__getitem__(name)
     
@@ -197,16 +185,16 @@ class ThermalInterfaceUpdate(
     def get_item_oapg(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
+    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> typing.Union[MetaOapg.properties.area, schemas.Unset]: ...
+    
+    @typing.overload
+    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> typing.Union[MetaOapg.properties.material, schemas.Unset]: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["componentA"]) -> typing.Union[MetaOapg.properties.componentA, schemas.Unset]: ...
@@ -229,18 +217,18 @@ class ThermalInterfaceUpdate(
     @typing.overload
     def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
     
-    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
+    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
         return super().get_item_oapg(name)
     
 
     def __new__(
         cls,
         *_args: typing.Union[dict, frozendict.frozendict, ],
-        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, ],
-        material: typing.Union[MetaOapg.properties.material, str, ],
         name: typing.Union[MetaOapg.properties.name, str, ],
         sideB: typing.Union[MetaOapg.properties.sideB, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
         sideA: typing.Union[MetaOapg.properties.sideA, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
+        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, schemas.Unset] = schemas.unset,
+        material: typing.Union[MetaOapg.properties.material, str, schemas.Unset] = schemas.unset,
         componentA: typing.Union[MetaOapg.properties.componentA, str, schemas.Unset] = schemas.unset,
         componentB: typing.Union[MetaOapg.properties.componentB, str, schemas.Unset] = schemas.unset,
         surfaceA: typing.Union[MetaOapg.properties.surfaceA, str, schemas.Unset] = schemas.unset,
@@ -253,11 +241,11 @@ class ThermalInterfaceUpdate(
         return super().__new__(
             cls,
             *_args,
-            area=area,
-            material=material,
             name=name,
             sideB=sideB,
             sideA=sideA,
+            area=area,
+            material=material,
             componentA=componentA,
             componentB=componentB,
             surfaceA=surfaceA,

--- a/sedaro/src/sedaro_base_client/model/thermal_interface_update.pyi
+++ b/sedaro/src/sedaro_base_client/model/thermal_interface_update.pyi
@@ -35,21 +35,13 @@ class ThermalInterfaceUpdate(
 
     class MetaOapg:
         required = {
-            "area",
-            "material",
             "name",
             "sideB",
             "sideA",
         }
         
         class properties:
-            
-            
-            class name(
-                schemas.StrSchema
-            ):
-                pass
-            area = schemas.NumberSchema
+            name = schemas.StrSchema
             
             
             class sideA(
@@ -122,6 +114,7 @@ class ThermalInterfaceUpdate(
                         _configuration=_configuration,
                         **kwargs,
                     )
+            area = schemas.NumberSchema
             material = schemas.StrSchema
             componentA = schemas.StrSchema
             componentB = schemas.StrSchema
@@ -131,9 +124,9 @@ class ThermalInterfaceUpdate(
             coolerB = schemas.StrSchema
             __annotations__ = {
                 "name": name,
-                "area": area,
                 "sideA": sideA,
                 "sideB": sideB,
+                "area": area,
                 "material": material,
                 "componentA": componentA,
                 "componentB": componentB,
@@ -143,8 +136,6 @@ class ThermalInterfaceUpdate(
                 "coolerB": coolerB,
             }
     
-    area: MetaOapg.properties.area
-    material: MetaOapg.properties.material
     name: MetaOapg.properties.name
     sideB: MetaOapg.properties.sideB
     sideA: MetaOapg.properties.sideA
@@ -153,13 +144,13 @@ class ThermalInterfaceUpdate(
     def __getitem__(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
+    
+    @typing.overload
+    def __getitem__(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
     
     @typing.overload
     def __getitem__(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
@@ -185,7 +176,7 @@ class ThermalInterfaceUpdate(
     @typing.overload
     def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
     
-    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
+    def __getitem__(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
         # dict_instance[name] accessor
         return super().__getitem__(name)
     
@@ -194,16 +185,16 @@ class ThermalInterfaceUpdate(
     def get_item_oapg(self, name: typing_extensions.Literal["name"]) -> MetaOapg.properties.name: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> MetaOapg.properties.area: ...
-    
-    @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideA"]) -> MetaOapg.properties.sideA: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["sideB"]) -> MetaOapg.properties.sideB: ...
     
     @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> MetaOapg.properties.material: ...
+    def get_item_oapg(self, name: typing_extensions.Literal["area"]) -> typing.Union[MetaOapg.properties.area, schemas.Unset]: ...
+    
+    @typing.overload
+    def get_item_oapg(self, name: typing_extensions.Literal["material"]) -> typing.Union[MetaOapg.properties.material, schemas.Unset]: ...
     
     @typing.overload
     def get_item_oapg(self, name: typing_extensions.Literal["componentA"]) -> typing.Union[MetaOapg.properties.componentA, schemas.Unset]: ...
@@ -226,18 +217,18 @@ class ThermalInterfaceUpdate(
     @typing.overload
     def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
     
-    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "area", "sideA", "sideB", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
+    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["name", "sideA", "sideB", "area", "material", "componentA", "componentB", "surfaceA", "surfaceB", "coolerA", "coolerB", ], str]):
         return super().get_item_oapg(name)
     
 
     def __new__(
         cls,
         *_args: typing.Union[dict, frozendict.frozendict, ],
-        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, ],
-        material: typing.Union[MetaOapg.properties.material, str, ],
         name: typing.Union[MetaOapg.properties.name, str, ],
         sideB: typing.Union[MetaOapg.properties.sideB, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
         sideA: typing.Union[MetaOapg.properties.sideA, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, bool, None, list, tuple, bytes, io.FileIO, io.BufferedReader, ],
+        area: typing.Union[MetaOapg.properties.area, decimal.Decimal, int, float, schemas.Unset] = schemas.unset,
+        material: typing.Union[MetaOapg.properties.material, str, schemas.Unset] = schemas.unset,
         componentA: typing.Union[MetaOapg.properties.componentA, str, schemas.Unset] = schemas.unset,
         componentB: typing.Union[MetaOapg.properties.componentB, str, schemas.Unset] = schemas.unset,
         surfaceA: typing.Union[MetaOapg.properties.surfaceA, str, schemas.Unset] = schemas.unset,
@@ -250,11 +241,11 @@ class ThermalInterfaceUpdate(
         return super().__new__(
             cls,
             *_args,
-            area=area,
-            material=material,
             name=name,
             sideB=sideB,
             sideA=sideA,
+            area=area,
+            material=material,
             componentA=componentA,
             componentB=componentB,
             surfaceA=surfaceA,

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,8 +1,7 @@
 HOST = 'http://localhost:80'
 
-# Update these variables below to be the API key of a user in your dev environment.
-# Also update the branch variables to the Wildfire Agent Template and Wildfire Scenario Branch id's that are connected
-# to that same user.
-API_KEY = '1.jd8KABYSWWJ_VQ8dzW_78whf47VLhuHCn8X1n7PcGjK50zezvGSTE9vGWJEgVj5Xvo_FwOBGfITjrOJ5GDuwFQ'
-WILDFIRE_A_T_ID = 59
-WILDFIRE_SCENARIO_ID = 61
+API_KEY = 'your api key here'
+WILDFIRE_A_T_ID = 0  # Wildfire agent template branch id
+WILDFIRE_SCENARIO_ID = 0  # Wildfare scenario branch id
+
+# NOTE: branch id's must be connected to the user with the given API key


### PR DESCRIPTION
## Task Link (if applicable)
- None

## Describe Your Changes
- Add ability to auto test sedaro package from local, test.pypi, and pypi in python 3.7 - 3.10 automatically
- Add some error handling in tests
- Add procedure in a readme for "Publishing to Python Package Index"
- Statically define dependencies in toml file
- Update version number
- Update sedaro base client

## Sibling Branches/MRs
- None

## Next Steps?
- Publish most up to date package to pypi

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.7 - 3.10
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to use `DRAFT:` until MR is ready
