### PR TITLE
Prevent intermittent progress bar error

### DIFF
--- a/sedaro/src/sedaro/results/simulation.py
+++ b/sedaro/src/sedaro/results/simulation.py
@@ -11,7 +11,6 @@ from sedaro.results.agent import SedaroAgentResult
 from sedaro.results.utils import (HFILL, STATUS_ICON_MAP,
                                   _get_agent_id_name_map, _restructure_data,
                                   hfill, progress_bar)
-from sedaro_base_client.apis.tags import jobs_api
 
 
 class SedaroSimulationResult:

--- a/sedaro/src/sedaro/results/utils.py
+++ b/sedaro/src/sedaro/results/utils.py
@@ -30,9 +30,10 @@ def hfill(char="-", len=HFILL):
 
 
 def progress_bar(progress):
-    blocks = int(progress * 50 / 100)
-    bar = '[' + ('■' * blocks + '□'*(50 - blocks)).ljust(50) + f'] ({progress:.2f}%)'
-    print(bar, end='\r')
+    if progress is not None:
+        blocks = int(progress * 50 / 100)
+        bar = '[' + ('■' * blocks + '□'*(50 - blocks)).ljust(50) + f'] ({progress:.2f}%)'
+        print(bar, end='\r')
 
 
 def _element_id_dict(agent_data):


### PR DESCRIPTION
Applies a fix for an intermittent progress bar error that occurs when `progress` is `None`.