### PR TITLE
Get results by agent

### DIFF
--- a/sedaro/README.md
+++ b/sedaro/README.md
@@ -248,7 +248,7 @@ For example, with the following code, `results` will only contain data for all e
 selected_streams=[
     ('foo'),
     ('bar', 'Thermal'),
-    ('bar', 'Power)
+    ('bar', 'Power')
 ]
 results = SedaroSimulationResult.get_scenario_latest(api_key, scenario_branch_id, streams=selected_streams)
 ```

--- a/sedaro/README.md
+++ b/sedaro/README.md
@@ -240,11 +240,7 @@ You can also use an optional kwarg, `streams`, with either of the above function
 
 * Each tuple in the list can contain either 1 or 2 items.
 * If a tuple contains 1 item, that item must be the agent ID, as a string. Data for all engines of this agent will be fetched. Remember that a 1-item tuple is written like `(foo,)`, NOT like `(foo)`.
-* If a tuple contains 2 items, the first item must be the same as above. The second item must be one of the following strings, specifying an engine. Data for the specified agent of this engine will be fetched.
-** 'GNC'
-** 'C&DH'
-** 'Thermal'
-** 'Power'
+* If a tuple contains 2 items, the first item must be the same as above. The second item must be one of the following strings, specifying an engine: `'GNC`, `'C&DH'`, `'Thermal'`, `'Power'`. Data for the specified agent of this engine will be fetched.
 
 For example, with the following code, `results` will only contain data for all engines of agent `foo` and the `Power` and `Thermal` engines of agent `bar`.
 

--- a/sedaro/README.md
+++ b/sedaro/README.md
@@ -246,7 +246,7 @@ For example, with the following code, `results` will only contain data for all e
 
 ```py
 selected_streams=[
-    ('foo'),
+    ('foo',),
     ('bar', 'Thermal'),
     ('bar', 'Power')
 ]

--- a/sedaro/README.md
+++ b/sedaro/README.md
@@ -255,6 +255,43 @@ results = SedaroSimulationResult.get_scenario_latest(api_key, scenario_branch_id
 
 Any object in the results API will provide a descriptive summary of its contents when the `.summarize` method is called. See the `results_api_demo` notebook in the [modsim notebooks](https://github.com/sedaro/modsim-notebooks) repository for more examples.
 
+## Use: Fetch Raw Data
+
+As an alternative to calling the functions in the `SedaroSimulationResult` class, you also fetch raw data directly from the `SedaroApiClient` class, with extra options not available when calling those functions.
+
+```py
+with SedaroApiClient(api_key=API_KEY) as sedaro:
+
+    # Instantiate sim client
+    sim = sedaro.get_sim_client(SCENARIO_BRANCH_ID)
+
+    # Start simulation
+    sim.start()
+
+    # Get simulation
+    job_res = sim.get_latest()[0]
+    
+    # Get raw data
+    selected_streams=[
+        ('foo',),
+        ('bar', 'Thermal'),
+        ('bar', 'Power')
+    ]
+    data = sedaro.get_data(job_res['dataArray'], start=65000, stop=65001, limit=250, streams=selected_streams, axisOrder='TIME_MINOR')
+    ### alternative:
+    data = sedaro.get_data(job_res['dataArray'], start=65000, stop=65001, binWidth=0.004, streams=selected_streams, axisOrder='TIME_MINOR')
+```
+
+All arguments except the first are optional.
+
+Optional arguments:
+* `start` (float): the start time of the data to fetch, in MJD format. Defaults to the start of the simulation.
+* `stop` (float): the end time of the data to fetch, in MJD format. Defaults to the end of the simulation.
+* `limit` (int): the maximum number of points in time for which to fetch data for any stream. If not specified, there is no limit and data is fetched at full resolution. If a limit is specified, the duration of the time from `start` to `stop` is divided into the specified number of bins of equal duration, and data is selected from at most one point in time within each bin. Not that it is not guaranteed that you will receive exactly as many points in time as the limit you specify; you may receive fewer, depending on the length of a data stream and/or the distribution of data point timestamps through the simulation.
+* `binWidth` (float): the width of the bins used in downsampling data, as described for `limit`. Note that `binWidth` and `limit` are not meant to be used together; undefined behavior may occur. If you would like to downsample data, use either `limit` or `binWidth`, but not both.
+* `streams` (list): specify which data streams you would like to fetch data for, according to the format described in the previous section. If no list is provided, data is fetched for all streams.
+* `axisOrder` (enum): the shape of each series in the response. Options: `'TIME_MAJOR'` and `'TIME_MINOR'`. Default value, if not specified, is `'TIME_MAJOR'`.
+
 ## Use: Send Requests
 
 Use built-in method to send customized requests to the host. See [OpenAPI Specification](https://sedaro.github.io/openapi/) for documentation on resource paths and body params.

--- a/sedaro/README.md
+++ b/sedaro/README.md
@@ -236,6 +236,27 @@ Alternatively, use the `.poll_scenario_latest` method to wait for an in-progress
 results = SedaroSimulationResult.poll_scenario_latest(api_key, scenario_branch_id)
 ```
 
+You can also use an optional kwarg, `streams`, with either of the above functions, to fetch results only from specific streams that you specify. If no argument is provided for `streams`, all data will be fetched. If you pass an argument to `streams`, it must be a list of tuples following particular rules:
+
+* Each tuple in the list can contain either 1 or 2 items.
+* If a tuple contains 1 item, that item must be the agent ID, as a string. Data for all engines of this agent will be fetched. Remember that a 1-item tuple is written like `(foo,)`, NOT like `(foo)`.
+* If a tuple contains 2 items, the first item must be the same as above. The second item must be one of the following strings, specifying an engine. Data for the specified agent of this engine will be fetched.
+** 'GNC'
+** 'C&DH'
+** 'Thermal'
+** 'Power'
+
+For example, with the following code, `results` will only contain data for all engines of agent `foo` and the `Power` and `Thermal` engines of agent `bar`.
+
+```py
+selected_streams=[
+    ('foo'),
+    ('bar', 'Thermal'),
+    ('bar', 'Power)
+]
+results = SedaroSimulationResult.get_scenario_latest(api_key, scenario_branch_id, streams=selected_streams)
+```
+
 Any object in the results API will provide a descriptive summary of its contents when the `.summarize` method is called. See the `results_api_demo` notebook in the [modsim notebooks](https://github.com/sedaro/modsim-notebooks) repository for more examples.
 
 ## Use: Send Requests

--- a/sedaro/src/sedaro/results/simulation.py
+++ b/sedaro/src/sedaro/results/simulation.py
@@ -4,7 +4,7 @@ import gzip
 import json
 import time
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from sedaro import SedaroApiClient
 from sedaro.results.agent import SedaroAgentResult
@@ -50,9 +50,10 @@ class SedaroSimulationResult:
         api_key: str,
         scenario_id: int,
         host: str = 'https://api.sedaro.com',
-        streams: List[Tuple[str, ...]] = []
+        streams: Optional[List[Tuple[str, ...]]] = None
     ):
         '''Query latest scenario result.'''
+        streams = streams or []
         with SedaroApiClient(api_key=api_key, host=host) as sedaro_client:
             simulation = cls.__get_simulation(sedaro_client, scenario_id)
             if simulation['status'] == 'SUCCEEDED':
@@ -67,10 +68,11 @@ class SedaroSimulationResult:
         api_key: str,
         scenario_id: int,
         host: str = 'https://api.sedaro.com',
-        streams: List[Tuple[str, ...]] = [],
+        streams: Optional[List[Tuple[str, ...]]] = None,
         retry_interval: int = 2
     ):
         '''Query latest scenario result and wait for sim if it is running.'''
+        streams = streams or []
         with SedaroApiClient(api_key=api_key, host=host) as sedaro_client:
             simulation = cls.__get_simulation(sedaro_client, scenario_id)
 

--- a/sedaro/src/sedaro/sedaro_api_client.py
+++ b/sedaro/src/sedaro/sedaro_api_client.py
@@ -1,5 +1,6 @@
+import base64
 import json
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 from sedaro_base_client import Configuration
 from sedaro_base_client.api_client import ApiClient
@@ -42,7 +43,15 @@ class SedaroApiClient(ApiClient):
             path_params={'branchId': id}, **COMMON_API_KWARGS)
         return BranchClient(body_from_res(res), self)
 
-    def get_data(self, id, start: float = None, stop: float = None, binWidth: float = None, limit: float = None, axisOrder: str = None):
+    def get_data(self,
+            id,
+            start: float = None,
+            stop: float = None,
+            binWidth: float = None,
+            limit: float = None,
+            axisOrder: str = None,
+            streams: List[Tuple[str, ...]] = []
+        ):
         """Simplified Data Service getter with significantly higher performance over the Swagger-generated client."""
         url = f'/data/{id}?'
         if start is not None:
@@ -53,6 +62,9 @@ class SedaroApiClient(ApiClient):
             url += f'&binWidth={binWidth}'
         elif limit is not None:
             url += f'&limit={limit}'
+        if len(streams) > 0:
+            encoded_streams = base64.b64encode(bytes(json.dumps(streams), encoding='utf-8')).decode('utf-8')
+            url += f'&streams={encoded_streams}'
         if axisOrder is not None:
             if axisOrder not in {'TIME_MAJOR',  'TIME_MINOR'}:
                 raise ValueError(

--- a/sedaro/src/sedaro/sedaro_api_client.py
+++ b/sedaro/src/sedaro/sedaro_api_client.py
@@ -50,7 +50,7 @@ class SedaroApiClient(ApiClient):
             binWidth: float = None,
             limit: float = None,
             axisOrder: str = None,
-            streams: List[Tuple[str, ...]] = []
+            streams: Optional[List[Tuple[str, ...]]] = None
         ):
         """Simplified Data Service getter with significantly higher performance over the Swagger-generated client."""
         url = f'/data/{id}?'
@@ -62,6 +62,7 @@ class SedaroApiClient(ApiClient):
             url += f'&binWidth={binWidth}'
         elif limit is not None:
             url += f'&limit={limit}'
+        streams = streams or []
         if len(streams) > 0:
             encoded_streams = base64.b64encode(bytes(json.dumps(streams), encoding='utf-8')).decode('utf-8')
             url += f'&streams={encoded_streams}'

--- a/sedaro/src/sedaro/sedaro_api_client.py
+++ b/sedaro/src/sedaro/sedaro_api_client.py
@@ -64,8 +64,8 @@ class SedaroApiClient(ApiClient):
             url += f'&limit={limit}'
         streams = streams or []
         if len(streams) > 0:
-            encoded_streams = base64.b64encode(bytes(json.dumps(streams), encoding='utf-8')).decode('utf-8')
-            url += f'&streams={encoded_streams}'
+            encodedStreams = ','.join(['.'.join(x) for x in streams])
+            url += f'&streams={encodedStreams}'
         if axisOrder is not None:
             if axisOrder not in {'TIME_MAJOR',  'TIME_MINOR'}:
                 raise ValueError(

--- a/sedaro/src/sedaro/sedaro_api_client.py
+++ b/sedaro/src/sedaro/sedaro_api_client.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 from sedaro_base_client import Configuration
 from sedaro_base_client.api_client import ApiClient


### PR DESCRIPTION
## Task Link (if applicable)
- N/A

## Describe Your Changes
- Adds support for getting results for only specified agents, using the `streams` kwarg. The argument passed to `streams` must conform to the format described in the sibling branch.

## Sibling Branches/MRs
- https://gitlab.sedaro.com/sedaro-satellite/satellite-app/-/merge_requests/807

## Next Steps?
- N/A

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.8 - 3.10 (NOTE: 3.7 does not install on my M1 machine)
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
