### PR TITLE
Remove 'Data' label from results

### DIFF
--- a/sedaro/src/sedaro/results/simulation.py
+++ b/sedaro/src/sedaro/results/simulation.py
@@ -32,8 +32,8 @@ class SedaroSimulationResult:
         self.__data = data
         self.__branch = simulation['branch']
         if self.success:
-            self.__meta = data['Data']['meta']
-            raw_series = data['Data']['series']
+            self.__meta = data['meta']
+            raw_series = data['series']
             agent_id_name_map = _get_agent_id_name_map(self.__meta)
             self.__simpleseries, self._agent_blocks = _restructure_data(raw_series, agent_id_name_map, self.__meta)
         else:


### PR DESCRIPTION
## Task Link (if applicable)
N/A

## Describe Your Changes
Removes the 'Data' label from the data service response object when fetching data.

## Sibling Branches/MRs
- https://gitlab.sedaro.com/sedaro-satellite/satellite-app/-/merge_requests/803
- https://gitlab.sedaro.com/sedaro-satellite/satellite-web/-/merge_requests/658

## Next Steps?
- N/A

## Checklist
- [ ] Necessary new tests added and documentation written
- [ ] Thorough self-review
- [ ] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [ ] All tests are passing for python 3.7 - 3.10
- [ ] No remaining forbidden code tags (`FIXME`, etc.)
- [ ] No new lint introduced
- [ ] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [ ] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
