### PR TITLE
openapi generation changing tuples

### DIFF
--- a/client_generator/__main__.py
+++ b/client_generator/__main__.py
@@ -121,7 +121,7 @@ def run_generator(skip_intro=False, language=None, how_to_proceed=None, spec_pat
             )
 
         # ----- generate client -----
-        cmd = f'docker run --rm -v "${{PWD}}:/local" openapitools/openapi-generator-cli generate \
+        cmd = f'docker run --rm -v "${{PWD}}:/local" openapitools/openapi-generator-cli:v6.6.0 generate \
                 -i /local{TEMP_SPEC_LOCATION[1:]} \
                 -g {language} \
                 -o /local/{BASE_CLIENT_BUILD_DIR}'

--- a/sedaro/src/sedaro/branch_client.py
+++ b/sedaro/src/sedaro/branch_client.py
@@ -136,6 +136,8 @@ class BranchClient:
     """A Sedaro `Block` class on an `AgentTemplate` branch"""
     Component: BlockClassClient
     """A Sedaro `Block` class on an `AgentTemplate` branch"""
+    ComponentToScalarCondition: BlockClassClient
+    """A Sedaro `Block` class on an `AgentTemplate` branch"""
     CompoundCondition: BlockClassClient
     """A Sedaro `Block` class on an `AgentTemplate` branch"""
     Cooler: BlockClassClient

--- a/tests/test_bcc_options.py
+++ b/tests/test_bcc_options.py
@@ -19,6 +19,7 @@ agent_template_blocks = [
     'CelestialVector',
     'CircularFieldOfView',
     'Component',
+    'ComponentToScalarCondition',
     'CompoundCondition',
     'Cooler',
     'CooperativeTransmitInterface',
@@ -112,7 +113,7 @@ def test_block_class_client_options():
         with SedaroApiClient(api_key=API_KEY, host=HOST) as sedaro:
             branch = sedaro.get_branch(branch_id)
             branch_blocks = sorted(branch.data['_block_names'])
-
+            print(set(branch_blocks)-set(blocks))
             # CHECK: lists above are correct
             assert blocks == branch_blocks
 

--- a/tests/test_bcc_options.py
+++ b/tests/test_bcc_options.py
@@ -113,7 +113,6 @@ def test_block_class_client_options():
         with SedaroApiClient(api_key=API_KEY, host=HOST) as sedaro:
             branch = sedaro.get_branch(branch_id)
             branch_blocks = sorted(branch.data['_block_names'])
-            print(set(branch_blocks)-set(blocks))
             # CHECK: lists above are correct
             assert blocks == branch_blocks
 

--- a/tests/test_block_crud.py
+++ b/tests/test_block_crud.py
@@ -244,7 +244,7 @@ def test_active_comm_interfaces_tuple():
             )
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # Check int at wrong index
         try:
             branch.crud(
@@ -252,7 +252,7 @@ def test_active_comm_interfaces_tuple():
             )
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # Check bool at wrong index
         try:
             branch.crud(
@@ -260,7 +260,7 @@ def test_active_comm_interfaces_tuple():
             )
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # Check string at wrong index
         try:
             branch.crud(
@@ -268,7 +268,7 @@ def test_active_comm_interfaces_tuple():
             )
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # Check size less than 3
         try:
             branch.crud(
@@ -276,7 +276,7 @@ def test_active_comm_interfaces_tuple():
             )
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # Check size greater than 3
         try:
             branch.crud(
@@ -284,7 +284,7 @@ def test_active_comm_interfaces_tuple():
             )
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
 
         assert True
 
@@ -304,7 +304,7 @@ def test_attitude_solution_error_tuple():
             )
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # Check size greater than 3
         try:
             branch.crud(
@@ -312,7 +312,7 @@ def test_attitude_solution_error_tuple():
             )
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # Check non-float values
         for i in range(len(validList)):
             failList = validList.copy()
@@ -323,7 +323,7 @@ def test_attitude_solution_error_tuple():
                 )
                 assert False
             except SedaroApiException as e:
-                print(e)
+                pass
         # Check non-list value
         try:
             branch.crud(
@@ -331,7 +331,7 @@ def test_attitude_solution_error_tuple():
             )
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
 
         assert True
 
@@ -370,7 +370,7 @@ def test_power_command_tuple():
             'powerCommand':["Fail", 0.5]}])
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # Check size greater than 2
         try:
             branch.crud(blocks=[{
@@ -379,7 +379,7 @@ def test_power_command_tuple():
             'powerCommand':[0.25, 0.5, 0.75]}])
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # Check size less than 2
         try:
             branch.crud(blocks=[{
@@ -388,7 +388,7 @@ def test_power_command_tuple():
             'powerCommand':[]}])
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # Check non-list value
         try:
             branch.crud(blocks=[{
@@ -397,7 +397,7 @@ def test_power_command_tuple():
             'powerCommand':"Fail"}])
             assert False
         except SedaroApiException as e:
-            print(e)
+            pass
         # All tests passed
         assert True
 

--- a/tests/test_block_crud.py
+++ b/tests/test_block_crud.py
@@ -2,12 +2,12 @@ import string
 from random import choices
 
 import pytest
-from config import API_KEY, HOST, SIMPLESAT_A_T_ID
+from config import API_KEY, HOST, SIMPLESAT_A_T_ID, WILDFIRE_SCENARIO_ID
 
 from sedaro import SedaroApiClient
 from sedaro.block_client import BlockClient
 from sedaro.branch_client import BranchClient
-from sedaro.exceptions import NonexistantBlockError
+from sedaro.exceptions import NonexistantBlockError, SedaroApiException
 from sedaro.settings import ID
 
 _letters_and_numbers = string.ascii_uppercase + string.digits + string.ascii_lowercase
@@ -228,6 +228,178 @@ def test_ignore_id_and_type_in_create():
 
         subsystem.delete()
 
+# Check validation of the Vehicle Template activeCommInterfaces field
+def test_active_comm_interfaces_tuple():
+    with SedaroApiClient(api_key=API_KEY, host=HOST) as sedaro:
+        branch = sedaro.get_branch(SIMPLESAT_A_T_ID)
+        # Check valid tuples
+        if not branch.crud(
+            root={'activeCommInterfaces': [[False, "Comms", 5], [True, "Interface", 112]]}
+        ):
+            assert False
+        # Check invalid value type
+        try:
+            branch.crud(
+                root={'activeCommInterfaces': [[False, "Interface", 5], [0.5, "Interface", 5]]},
+            )
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # Check int at wrong index
+        try:
+            branch.crud(
+                root={'activeCommInterfaces': [[5, "Interface", 5]]},
+            )
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # Check bool at wrong index
+        try:
+            branch.crud(
+                root={'activeCommInterfaces': [[False, True, 5]]},
+            )
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # Check string at wrong index
+        try:
+            branch.crud(
+                root={'activeCommInterfaces': [[False, "Interface", "5"]]},
+            )
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # Check size less than 3
+        try:
+            branch.crud(
+                root={'activeCommInterfaces': [[False, "Interface"]]},
+            )
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # Check size greater than 3
+        try:
+            branch.crud(
+                root={'activeCommInterfaces': [[False, "Interface", 5, True]]},
+            )
+            assert False
+        except SedaroApiException as e:
+            print(e)
+
+        assert True
+
+# Check validation of the Vehicle Template attitudeSolutionError field
+def test_attitude_solution_error_tuple():
+    with SedaroApiClient(api_key=API_KEY, host=HOST) as sedaro:
+        branch = sedaro.get_branch(SIMPLESAT_A_T_ID)
+        validList = [0.25, 0.5, 0.75]
+        # Check valid tuple
+        if not branch.crud(root={'attitudeSolutionError': None}) or \
+            not branch.crud(root={'attitudeSolutionError': validList}):
+            assert False
+        # Check size less than 3
+        try:
+            branch.crud(
+                root={'attitudeSolutionError': validList[:-1]},
+            )
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # Check size greater than 3
+        try:
+            branch.crud(
+                root={'attitudeSolutionError': validList + [1.0]},
+            )
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # Check non-float values
+        for i in range(len(validList)):
+            failList = validList.copy()
+            failList[i] = "Fail"
+            try:
+                branch.crud(
+                    root={'attitudeSolutionError': failList},
+                )
+                assert False
+            except SedaroApiException as e:
+                print(e)
+        # Check non-list value
+        try:
+            branch.crud(
+                root={'attitudeSolutionError': 50},
+            )
+            assert False
+        except SedaroApiException as e:
+            print(e)
+
+        assert True
+
+# Check validation of the Solar Array powerCommand field
+def test_power_command_tuple():
+    with SedaroApiClient(api_key=API_KEY, host=HOST) as sedaro:
+        branch = sedaro.get_branch(SIMPLESAT_A_T_ID)
+        # Check valid tuples
+        if not branch.crud(blocks=[{
+            'type':"SolarArray",
+            'name':"Temp Array 1",
+            'powerCommand':[None, None]}]):
+            assert False
+        if not branch.crud(blocks=[{
+            'type':"SolarArray",
+            'name':"Temp Array 2",
+            'powerCommand':[0.0, None]}]):
+            assert False
+        if not branch.crud(blocks=[{
+            'type':"SolarArray",
+            'name':"Temp Array 3",
+            'powerCommand':[None, 0.5]}]):
+            assert False
+        if not branch.crud(blocks=[{
+            'type':"SolarArray",
+            'name':"Temp Array 4",
+            'powerCommand':[0.0, 0.5]}]):
+            assert False
+        # Delete created solar arrays
+        branch.crud(delete=branch.data['index']['SolarArray'])  
+        # Check non-float values
+        try:
+            branch.crud(blocks=[{
+            'type':"SolarArray",
+            'name':"Temp Array 1",
+            'powerCommand':["Fail", 0.5]}])
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # Check size greater than 2
+        try:
+            branch.crud(blocks=[{
+            'type':"SolarArray",
+            'name':"Temp Array 1",
+            'powerCommand':[0.25, 0.5, 0.75]}])
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # Check size less than 2
+        try:
+            branch.crud(blocks=[{
+            'type':"SolarArray",
+            'name':"Temp Array 1",
+            'powerCommand':[]}])
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # Check non-list value
+        try:
+            branch.crud(blocks=[{
+            'type':"SolarArray",
+            'name':"Temp Array 1",
+            'powerCommand':"Fail"}])
+            assert False
+        except SedaroApiException as e:
+            print(e)
+        # All tests passed
+        assert True
 
 def run_tests():
     test_get()
@@ -238,3 +410,6 @@ def run_tests():
     test_block_client_equality()
     test_block_client_clone()
     test_some_errors()
+    test_active_comm_interfaces_tuple()
+    test_attitude_solution_error_tuple()
+    test_power_command_tuple()


### PR DESCRIPTION
## Task Link (if applicable)
-

## Describe Your Changes
- Reverted OpenAPI Generator to version 6.6.0 since 7.0.0 changes the file structure and breaks the client
- Added ComponentToScalarCondition to the branch_client and bcc test
- Added tests for the new validators on fields that were changed from tuples to lists

## Sibling Branches/MRs
- satellite-app[!859](https://gitlab.sedaro.com/sedaro-satellite/satellite-app/-/merge_requests/859)

## Next Steps?
-

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [ ] All tests are passing for python 3.7 - 3.10
Works in 3.8 - 3.10, unable to test with python 3.7
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
