### PR TITLE
CRUD requests w ref ids

### DIFF
--- a/sedaro/README.md
+++ b/sedaro/README.md
@@ -161,6 +161,14 @@ The `crud` method is also available for performing operations on multiple Sedaro
 - `blocks`: create/update 1+ blocks by passing a list of dictionaries. If an `id` is present, the corresponding block will be updated. If an `id` isn't present, a new block will be created. The `type` is always required.
 - `delete`: delete 1+ blocks by passing a list of their block `id`s.
 
+In this method, relationship fields can point at existing `BlockID`'s or "ref id"s. A "ref id" is similar to a
+json "reference" and is used as follows:
+  - It is any string starting with `'$'`.
+  - It must be in the `id` field of a single `Block` dictionary created in this transaction.
+  - It can be referenced in any relationship field on root or any `Block` dictionary in this transaction.
+  - All instances of the "ref id" will be resolved to the corresponding created `Block`'s id.
+
+
 ```py
 branch.crud(
     root={ "field": "value" }, # update fields on root

--- a/sedaro/src/sedaro/branches/branch.py
+++ b/sedaro/src/sedaro/branches/branch.py
@@ -48,12 +48,20 @@ class Branch:
     ) -> 'dict':
         """Method to perform multiple CRUD operations at the same time.
 
+        In this method, relationship fields can point at existing `BlockID`'s or "ref id"s. A "ref id" is similar to a
+        json "reference" and is used as follows:
+        - It is any string starting with `'$'`.
+        - It must be in the `id` field of a single `Block` dictionary created in this transaction.
+        - It can be referenced in any relationship field on root or any `Block` dictionary in this transaction.
+        - All instances of the "ref id" will be resolved to the corresponding created `Block`'s id.
+
         Args:
             root (dict, optional): a `dict` of field/value pairs to update on the `root` of the branch template this\
                 method is called on. Defaults to `None`.
-            blocks (list, optional): a `list` of Block dictionaries. If there is an `id` in the `dict`, updates an\
-                existing Block, otherwise creates a new Block. Defaults to `None`.
-            delete (list, optional): a list of `id`s of Blocks to be deleted. Defaults to `None`.
+            blocks (list, optional): a `list` of `Block` dictionaries. `Block` dictionaries with no `id` or a "ref id"\
+                will be created, otherwise they should have an `id` field referencing an existing block and the\
+                dictionary will be used to update the `Block`. Defaults to `None`.
+            delete (list, optional): a list of `id`s of `Block`s to be deleted. Defaults to `None`.
 
         Raises:
             SedaroApiException: if there is an error in the response

--- a/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
+++ b/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
@@ -3,9 +3,8 @@ from contextlib import contextmanager
 from typing import (TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple,
                     Union)
 
-from sedaro_base_client.apis.tags import jobs_api
-from sedaro_base_client.apis.tags import externals_api
 import numpy as np
+from sedaro_base_client.apis.tags import externals_api, jobs_api
 
 from ...exceptions import NoSimResultsError, SedaroApiException
 from ...results import SimulationResult
@@ -476,10 +475,10 @@ class SimulationHandle:
                     'agentId': agent_id,
                     'externalStateBlockId': external_state_id,
                 },
-                body=(
-                    {'values': [serdes(v) for v in values]} |
-                    ({'timestamp': timestamp} if timestamp is not None else {})
-                ),
+                body=({
+                    **{'values': [serdes(v) for v in values]},
+                    **({'timestamp': timestamp} if timestamp is not None else {})
+                }),
                 **COMMON_API_KWARGS,
             )
         return tuple(serdes(v) for v in body_from_res(response))

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -3,10 +3,10 @@ import time
 
 import test_bcc_options
 import test_block_crud
+import test_externals
 import test_plain_requests
 import test_results
 import test_simulation
-import test_externals
 from config import HOST
 
 ############## IMPORT AND ADD TEST FILES HERE ##############

--- a/tests/test_block_crud.py
+++ b/tests/test_block_crud.py
@@ -334,10 +334,8 @@ def test_multiblock_crud_with_ref_ids():
     bc = branch.BatteryCell.get_where(partNumber=batt_cell_part_number)[0]
     try:
         assert bp.cell.id == bc.id
-    except AssertionError:
-        bp.delete()
-        bc.delete()
-        raise
+    finally:
+        branch.crud(delete=[bp.id, bc.id])
 
 def run_tests():
     test_get()


### PR DESCRIPTION
## Task Link (if applicable)
<img width="876" alt="Screenshot 2023-07-19 at 11 54 20 AM" src="https://github.com/sedaro/sedaro-python/assets/71565231/bce55e55-2231-4e3d-ac32-cf4c3ab5ed63">

## Describe Your Changes
- Add tests for multi-block crud with ref ids
- Update readme and doc string to explain ref ids
- Other:
  - update something that used a pipe operator on dicts to be backwards compatible with python 3.8 still

## Sibling Branches/MRs
- https://gitlab.sedaro.com/sedaro-satellite/nebula/-/merge_requests/17

## Next Steps?
- FIXME: update docs

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.8 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
