### PR TITLE
Move to subseries indexing over getattr

### DIFF
--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -45,10 +45,10 @@ class SedaroSeries:
             raise ValueError('Select a specific subseries to iterate over.')
         return (entry for entry in zip(self.__mjd, self.__elapsed_time, self.__series))
 
-    def __getattr__(self, subseries_name: str):
+    def __getitem__(self, subseries_name: str):
         '''Get a particular subseries by name.
 
-        Typically invoked by calling .<SUBSERIES_NAME> on an instance
+        Typically invoked by indexing [<SUBSERIES_NAME>] on an instance
         of SedaroSeries. Can only be called if the series has subseries.
         '''
         if not self.__has_subseries:
@@ -58,6 +58,10 @@ class SedaroSeries:
             return SedaroSeries(new_series_name, self.__mjd, self.__series[subseries_name])
         else:
             raise ValueError(f"Subseries '{subseries_name}' not found.")
+
+    def __getattr__(self, subseries_name: str):
+        '''Get a particular subseries by name as an attribute.'''
+        return self[subseries_name]
 
     @property
     def name(self):
@@ -170,6 +174,6 @@ class SedaroSeries:
 
         hfill()
         if self.__has_subseries:
-            print("❓ Call .<SUBSERIES_NAME> to select a subseries")
+            print("❓ Index [<SUBSERIES_NAME>] to select a subseries")
         else:
             print("❓ Call .plot to visualize results")


### PR DESCRIPTION
## Describe Your Changes
- Added sub-series indexing option and updated guidance to suggest that method instead of through `.` attributes.

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.8 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
