### PR TITLE
Block.type and null relationship handling rework

### DIFF
--- a/sedaro/src/sedaro/branches/blocks/block.py
+++ b/sedaro/src/sedaro/branches/blocks/block.py
@@ -40,7 +40,7 @@ class Block(Common):
     @property
     def type(self) -> str:
         '''Name of the class of the Sedaro Block this `Block` instance is set up to interact with'''
-        return self._block_type.type
+        return self.data[TYPE]
 
     @property
     def data(self) -> Dict:
@@ -113,10 +113,12 @@ class Block(Common):
             Block: updated `Block` (Note: the previous `Block` reference is also updated)
         """
         if is_empty(fields):
-            raise ValueError(f'Must provide fields to update on the {self.type}.')
+            raise ValueError(
+                f'Must provide fields to update on the {self.type}.')
 
         if ID in fields and fields[ID] != self.id:
-            raise ValueError(f'Invalid value for "{ID}". Omit or ensure it is the same as this Block\'s {ID}.')
+            raise ValueError(
+                f'Invalid value for "{ID}". Omit or ensure it is the same as this Block\'s {ID}.')
 
         # NOTE: `self.data` calls `self.enforce_still_exists()`, so don't need to call here
         self._branch.crud(blocks=[{**self.data, **fields}])

--- a/sedaro/src/sedaro/branches/common.py
+++ b/sedaro/src/sedaro/branches/common.py
@@ -49,6 +49,10 @@ class Common(ABC):
         if not self.is_rel_field(key):
             return val
 
+        # If relationship is undefined, return None
+        if val is None:
+            return None
+
         side_type = self.get_rel_field_type(key)
 
         if side_type == MANY_SIDE:


### PR DESCRIPTION
## Describe Your Changes

1. Updated `Block.type` to use the real/final type of the Block, not the `BlockType` used in the query to initially retrieve the Block.
2. Updated relationship traversal logic to return `None` (instead of raising an error) when a relationship is a null pointer.

## Checklist
- [X] Necessary new tests added and documentation written
- [X] Thorough self-review
- [X] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [X] All tests are passing for python 3.8 - 3.11
- [X] No remaining forbidden code tags (`FIXME`, etc.)
- [X] No new lint introduced
- [X] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [X] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
