### PR TITLE
Remove trailing forward slash from host

### DIFF
--- a/sedaro/src/sedaro/sedaro_api_client.py
+++ b/sedaro/src/sedaro/sedaro_api_client.py
@@ -16,6 +16,8 @@ class SedaroApiClient(ApiClient):
     """A client to interact with the Sedaro API"""
 
     def __init__(self, api_key, host='https://api.sedaro.com'):
+        if host[-1] == '/':
+            host = host[:-1]  # remove trailing forward slash
         self._api_key = api_key
         self._api_host = host
 


### PR DESCRIPTION
## Task Link or Description
This removes trailing forward slashes from the `host` address provided to `SedaroApiClient`.

## Describe Your Changes
Added a check in `SedaroApiClient.__init__()` that checks if the last character is a forward slash and removes it if present.

## Sibling Branches/MRs
-

## Next Steps?
-

## Checklist
- [ ] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [ ] All tests are passing for python 3.8 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
