### PR TITLE
hotfix: add msgpack import, change dependencies format for better diffs

### DIFF
--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -9,7 +9,21 @@ description = "A python client to interact with the Sedaro API."
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [ "Programming Language :: Python :: 3.8", "License :: OSI Approved :: GNU General Public License v3 (GPLv3)", "Operating System :: OS Independent", "Topic :: Software Development",]
-dependencies = [ "certifi >= 14.5.14", "flatdict ~= 4.0.1", "frozendict ~= 2.3.4", "python-dateutil ~= 2.7", "requests", "setuptools >= 21.0.0", "typing_extensions ~= 4.3.0", "urllib3 ~= 1.26.7", "pydash >= 5.1.1", "scipy >= 1.10.1", "numpy", "orjson"]
+dependencies = [
+    "certifi >= 14.5.14",
+    "flatdict ~= 4.0.1",
+    "frozendict ~= 2.3.4",
+    "python-dateutil ~= 2.7",
+    "setuptools >= 21.0.0",
+    "typing_extensions ~= 4.3.0",
+    "urllib3 ~= 1.26.7",
+    "pydash >= 5.1.1",
+    "scipy >= 1.10.1",
+    "numpy",
+    "msgpack",
+    "orjson",
+    "requests",
+    ]
 [[project.authors]]
 name = "Sedaro"
 email = "support@sedarotech.com"

--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "certifi >= 14.5.14",
     "flatdict ~= 4.0.1",
     "frozendict ~= 2.3.4",
+    "msgpack ~= 1.0.7",
     "python-dateutil ~= 2.7",
     "setuptools >= 21.0.0",
     "typing_extensions ~= 4.3.0",
@@ -20,7 +21,6 @@ dependencies = [
     "pydash >= 5.1.1",
     "scipy >= 1.10.1",
     "numpy",
-    "msgpack",
     "orjson",
     "requests",
     ]


### PR DESCRIPTION
Hotfix - msgpack import was missing from pyproject.toml. Put each dependency on its own line for cleaner diffs and easier-to-read format to avoid these problems in the future.