### PR TITLE
Use the correct id index from the crud response

### DIFF
--- a/sedaro/src/sedaro/branches/blocks/block.py
+++ b/sedaro/src/sedaro/branches/blocks/block.py
@@ -98,7 +98,7 @@ class Block(Common):
             blocks=[new_block]
         )
 
-        return self._branch.block(res[CRUD][BLOCKS][0])
+        return self._branch.block(res[CRUD][BLOCKS][-1])
 
     def update(self, **fields) -> 'Block':
         """Update attributes of the corresponding Sedaro Block

--- a/sedaro/src/sedaro/branches/blocks/block_type.py
+++ b/sedaro/src/sedaro/branches/blocks/block_type.py
@@ -48,7 +48,7 @@ class BlockType:
             fields.pop(kwarg, None)
 
         res = self._branch.crud(blocks=[{**fields, **{TYPE: self.type}}])
-        block_id = res[CRUD][BLOCKS][0]
+        block_id = res[CRUD][BLOCKS][-1]
         return Block(block_id, self)
 
     def get(self, id: Union[str, int]) -> Block:


### PR DESCRIPTION
## Task Link or Description
- Fix bug with wrong id being used in `create`/`clone` methods.

## Describe Your Changes
- Nebula now returns the ids of all `Block`s created/updated/deleted directly or indirectly in template crud requests.
- Since they're sorted, use the last one in the list in the `create` and `clone` methods.

## Sibling Branches/MRs
- None

## Next Steps?
- Most of the tests outside of the ones related to model service and data utils are failing :/ 

![Screenshot 2024-02-22 at 2 32 24 PM](https://github.com/sedaro/sedaro-python/assets/71565231/672f6ff6-b61b-4300-8e8a-22a3bf3a293d)

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [ ] All tests are passing for python 3.8 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
