### PR TITLE
Fix a few more bugs in overhauled Results API

### DIFF
--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -75,6 +75,8 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
         if not self.__has_subseries:
             raise ValueError('This series has no subseries.')
         else:
+            if type(subseries_name) == int:
+                subseries_name = str(subseries_name)
             if subseries_name not in self.__column_index:
                 raise ValueError(f"Subseries '{subseries_name}' not found.")
             else:

--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -104,8 +104,8 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
     @property
     def values(self):
         if not (self.__has_subseries and not self.__is_singleton_or_vector()):
-            if self.__has_subseries:
-                return self.__series.values.compute().tolist()
+            if not self.__has_subseries:
+                return self.__series[self.__column_names[0]].compute().tolist()
             else:
                 computed_columns = {column_name: self.__series[column_name].compute().tolist() for column_name in self.__series.columns}
                 vals = []

--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -75,7 +75,7 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
         if not self.__has_subseries:
             raise ValueError('This series has no subseries.')
         else:
-            if type(subseries_name) == int:
+            if type(subseries_name) is int:
                 subseries_name = str(subseries_name)
             if subseries_name not in self.__column_index:
                 raise ValueError(f"Subseries '{subseries_name}' not found.")


### PR DESCRIPTION
Fixes a couple bugs Paul found in my newly overhauled Results API.

1. fixes bug where indexing into subvars like x = attitudeError[0] crashed, and you had to instead do x = attitudeError['0']. It now will cast received int inputs to strings, making them handle properly.
2. Fixes two problems with behavior in SedaroSeries.values:
a. conditional was the inverse of what it should be
b. values of a single column were being displayed like [[1], [2], [3], [4], ...] instead of the correct [1, 2, 3, 4, ...]