### PR TITLE
Improved error message when no streams are found for a sim during results download

### DIFF
--- a/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
+++ b/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
@@ -406,7 +406,10 @@ class Simulation:
         if streams is not None and len(streams) > 0:
             filtered_streams = self.__get_filtered_streams(streams, metadata)
         else:
-            filtered_streams = metadata['streams']
+            try:
+                filtered_streams = metadata['streams']
+            except KeyError:
+                raise Exception(f"No series data found for simulation {sim_id}. This indicates that the simulation has just started running. Please try again after a short wait.")
         num_workers = min(num_workers, len(filtered_streams))
         workers = [[] for _ in range(num_workers)]
         for i, stream in enumerate(filtered_streams):


### PR DESCRIPTION
When a user of the client, without listing specific desired streams, requests results from a sim that has just started running and has not yet written any series data to the data service, the following unhelpful error occurs (thank you @zduvall for pointing this out):

<img width="953" alt="Screenshot 2024-03-11 at 4 02 11 PM" src="https://github.com/sedaro/sedaro-python/assets/127535673/ab21cac1-1550-4a27-81a7-80e7455c5cbf">

This PR replaces this with a more helpful error message.