### PR TITLE
Fix bug with vector .values in nested SedaroSeries

### DIFF
--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -117,8 +117,11 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
             else:
                 computed_columns = {nonprefixed_column_name(column_name): self.__series[column_name].compute().tolist() for column_name in self.__series.columns}
                 vals = []
+                num_indexes = -1
                 for column in computed_columns:
-                    indexes = [int(x) for x in column.split('.')][::-1]
+                    indexes = [int(x) for x in column.split('.')]
+                    if num_indexes == -1:
+                        num_indexes = len(indexes)
                     ptr = vals
                     for index in indexes:
                         if len(ptr) == index:
@@ -127,7 +130,8 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
                             ptr.extend([[] for _ in range(index - len(ptr))])
                         ptr = ptr[index]
                     ptr.extend(computed_columns[column])
-                return np.transpose(vals, axes=None).tolist()
+                rotated_indexes = tuple([num_indexes] + list(range(num_indexes)))
+                return np.transpose(vals, rotated_indexes).tolist()
 
         else:
             return {key: self.__getattr__(key).values for key in self.__column_index}

--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -116,11 +116,9 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
                 return self.__series[self.__column_names[0]].compute().tolist()
             else:
                 computed_columns = {nonprefixed_column_name(column_name): self.__series[column_name].compute().tolist() for column_name in self.__series.columns}
-                # print([k for k in computed_columns])
                 vals = []
                 for column in computed_columns:
-                    # print(f"column: {column}, prefix: {self.__prefix}")
-                    indexes = [int(x) for x in column.split('.')]
+                    indexes = [int(x) for x in column.split('.')][::-1]
                     ptr = vals
                     for index in indexes:
                         if len(ptr) == index:

--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -105,13 +105,21 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
 
     @property
     def values(self):
+        def nonprefixed_column_name(column_name):
+            if len(self.__prefix) > 0:
+                return column_name[len(self.__prefix)+1:]
+            else:
+                return column_name
+
         if not (self.__has_subseries and not self.__is_singleton_or_vector()):
             if not self.__has_subseries:
                 return self.__series[self.__column_names[0]].compute().tolist()
             else:
-                computed_columns = {column_name: self.__series[column_name].compute().tolist() for column_name in self.__series.columns}
+                computed_columns = {nonprefixed_column_name(column_name): self.__series[column_name].compute().tolist() for column_name in self.__series.columns}
+                # print([k for k in computed_columns])
                 vals = []
                 for column in computed_columns:
+                    # print(f"column: {column}, prefix: {self.__prefix}")
                     indexes = [int(x) for x in column.split('.')]
                     ptr = vals
                     for index in indexes:

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -259,6 +259,43 @@ def test_download():
     finally:
         shutil.rmtree(path)
 
+def test_series_values():
+    df = dd.from_dict({
+        'time': [0, 1, 2, 3, 4, 5],
+        'pref.a.0': [0, 1, 2, 3, 4, 5],
+        'pref.a.1': [0, 5, 10, 15, 20, 25],
+        'pref.b': [0, 2, 4, 6, 8, 10],
+        'pref.c.foo': [0, 3, 6, 9, 12, 15],
+        'pref.c.bar': [0, 4, 8, 12, 16, 20],
+        'pref.c.baz.0.0': [0, 6, 12, 18, 24, 30],
+        'pref.c.baz.0.1': [0, 7, 14, 21, 28, 35],
+        'pref.c.baz.1.0': [0, 8, 16, 24, 32, 40],
+        'pref.c.baz.1.1': [0, 9, 18, 27, 36, 45],
+        'pref.d.a': [0, 10, 20, 30, 40, 50],
+    }, npartitions=1)
+    df = df.set_index('time')
+
+    col_ind = {
+        'a': {'0': {}, '1': {}},
+        'b': {},
+        'c': {'foo': {}, 'bar': {}, 'baz': {'0': {'0': {}, '1': {}}, '1': {'0': {}, '1': {}}}},
+        'd': {'a': {}},
+    }
+
+    ser = SedaroSeries('pref', df, col_ind, 'pref')
+
+    print(ser.values)
+    assert ser.values == {
+        'a': [[0, 0], [1, 5], [2, 10], [3, 15], [4, 20], [5, 25]],
+        'b': [0, 2, 4, 6, 8, 10],
+        'c': {
+            'foo': [0, 3, 6, 9, 12, 15],
+            'bar': [0, 4, 8, 12, 16, 20],
+            'baz': [[[0, 0], [0, 0]], [[6, 7], [8, 9]], [[12, 14], [16, 18]], [[18, 21], [24, 27]], [[24, 28], [32, 36]], [[30, 35], [40, 45]]],
+        },
+        'd': {'a': [0, 10, 20, 30, 40, 50]},
+    }
+
 
 def run_tests():
     test_query_terminated()
@@ -266,3 +303,4 @@ def run_tests():
     test_save_load()
     test_query_model()
     test_download()
+    test_series_values()

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -284,7 +284,6 @@ def test_series_values():
 
     ser = SedaroSeries('pref', df, col_ind, 'pref')
 
-    print(ser.values)
     assert ser.values == {
         'a': [[0, 0], [1, 5], [2, 10], [3, 15], [4, 20], [5, 25]],
         'b': [0, 2, 4, 6, 8, 10],

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -295,6 +295,19 @@ def test_series_values():
         'd': {'a': [0, 10, 20, 30, 40, 50]},
     }
 
+    df2 = df[['pref.c.baz.0.0', 'pref.c.baz.0.1', 'pref.c.baz.1.0', 'pref.c.baz.1.1']]
+
+    col_ind2 = col_ind['c']['baz']
+    ser2 = SedaroSeries('pref.c.baz', df2, col_ind2, 'pref.c.baz')
+    assert ser2.values == [
+        [[0, 0], [0, 0]],
+        [[6, 7], [8, 9]],
+        [[12, 14], [16, 18]],
+        [[18, 21], [24, 27]],
+        [[24, 28], [32, 36]],
+        [[30, 35], [40, 45]],
+    ]
+
 
 def run_tests():
     test_query_terminated()


### PR DESCRIPTION
## Task Link or Description

Bug found by Zach while testing his API changes.
![image](https://github.com/sedaro/sedaro-python/assets/127535673/9543ba5a-a0db-4552-8fb3-7be5b259250e)

## Describe Your Changes
-Fixes a bug in SedaroSeries.values that causes a crash when the Series contains a vector that is nested within a non-vector subseries. Also fixes a bug, discovered during testing, that was resulting in multi-dimensional vectors being transposed improperly.
-Adds unit tests for SedaroSeries.values.

## Sibling Branches/MRs
-

## Next Steps?
-

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [ ] All tests are passing for python 3.8 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
