### PR TITLE
Filter dot files from parquet data

### DIFF
--- a/sedaro/src/sedaro/results/agent.py
+++ b/sedaro/src/sedaro/results/agent.py
@@ -7,7 +7,7 @@ from typing import Dict, Generator, List, Union
 from pydash import merge
 
 from .block import SedaroBlockResult
-from .utils import ENGINE_EXPANSION, ENGINE_MAP, HFILL, bsearch, hfill, FromFileAndToFileAreDeprecated
+from .utils import ENGINE_EXPANSION, ENGINE_MAP, HFILL, FromFileAndToFileAreDeprecated, bsearch, get_parquets, hfill
 
 
 class SedaroAgentResult(FromFileAndToFileAreDeprecated):
@@ -109,8 +109,7 @@ class SedaroAgentResult(FromFileAndToFileAreDeprecated):
             initial_state = meta['initial_state']
             column_index = meta['column_index']
         engines = {}
-        parquets = os.listdir(f"{path}/data/")
-        for engine in parquets:
+        for engine in get_parquets(f"{path}/data/"):
             df = dd.read_parquet(f"{path}/data/{engine}")
             engines[engine.replace('.', '/')] = df
         return cls(name, block_structures, engines, column_index, initial_state)

--- a/sedaro/src/sedaro/results/block.py
+++ b/sedaro/src/sedaro/results/block.py
@@ -5,7 +5,8 @@ from pathlib import Path
 from typing import Dict, Generator, Union
 
 from .series import SedaroSeries
-from .utils import ENGINE_EXPANSION, ENGINE_MAP, HFILL, get_column_names, hfill, FromFileAndToFileAreDeprecated
+from .utils import (ENGINE_EXPANSION, ENGINE_MAP, HFILL, FromFileAndToFileAreDeprecated, get_column_names, get_parquets,
+                    hfill)
 
 
 class SedaroBlockResult(FromFileAndToFileAreDeprecated):
@@ -120,8 +121,7 @@ class SedaroBlockResult(FromFileAndToFileAreDeprecated):
             column_index = meta['column_index']
             prefix = meta['prefix']
         engines = {}
-        parquets = os.listdir(f"{path}/data/")
-        for agent in parquets:
+        for agent in get_parquets(f"{path}/data/"):
             df = dd.read_parquet(f"{path}/data/{agent}")
             engines[agent.replace('.', '/')] = df
         return cls(structure, engines, column_index, prefix)

--- a/sedaro/src/sedaro/results/simulation_result.py
+++ b/sedaro/src/sedaro/results/simulation_result.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Dict, List, Union
 
 from .agent import SedaroAgentResult
-from .utils import (HFILL, STATUS_ICON_MAP, _block_type_in_supers,
-                    _get_agent_id_name_map, _restructure_data, hfill, FromFileAndToFileAreDeprecated)
+from .utils import (HFILL, STATUS_ICON_MAP, FromFileAndToFileAreDeprecated, _block_type_in_supers,
+                    _get_agent_id_name_map, _restructure_data, get_parquets, hfill)
 
 
 class SimulationResult(FromFileAndToFileAreDeprecated):
@@ -137,9 +137,8 @@ class SimulationResult(FromFileAndToFileAreDeprecated):
             contents = json.load(fp)
             simulation = contents['simulation']
             data['meta'] = contents['meta']
-        parquets = os.listdir(f"{path}/data/")
         data['series'] = {}
-        for agent in parquets:
+        for agent in get_parquets(f"{path}/data/"):
             df = dd.read_parquet(f"{path}/data/{agent}")
             data['series'][agent.replace('.', '/')] = df
         return cls(simulation, data)

--- a/sedaro/src/sedaro/results/utils.py
+++ b/sedaro/src/sedaro/results/utils.py
@@ -1,5 +1,5 @@
 import math
-import numpy as np
+from os import listdir
 from pathlib import Path
 from typing import Union
 
@@ -163,6 +163,11 @@ def get_column_names(column_index, prefix):
         for key in column_index:
             columns.extend(get_column_names(column_index[key], f"{prefix}{key}"))
         return columns
+
+
+def get_parquets(path: str):
+    paths = listdir(path)
+    return [parquet for parquet in paths if not parquet.startswith('.')]
 
 
 class FromFileAndToFileAreDeprecated:

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -96,21 +96,26 @@ def test_save_load():
     with TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "sim.bak"
         result.save(file_path)
+        # test that .DS_STORE, etc. doesn't interfere with loading
+        os.system(f"touch {temp_dir}/.DS_STORE")
         new_result = SimulationResult.load(file_path)
 
         file_path = Path(temp_dir) / "agent.bak"
         agent_result = new_result.agent(new_result.templated_agents[0])
         agent_result.save(file_path)
+        os.system(f"touch {temp_dir}/.DS_STORE")
         new_agent_result = SedaroAgentResult.load(file_path)
 
         file_path = Path(temp_dir) / "block.bak"
         block_result = new_agent_result.block('root')
         block_result.save(file_path)
+        os.system(f"touch {temp_dir}/.DS_STORE")
         new_block_result = SedaroBlockResult.load(file_path)
 
         file_path = Path(temp_dir) / "series.bak"
         series_result = new_block_result.position.ecef
         series_result.save(file_path)
+        os.system(f"touch {temp_dir}/.DS_STORE")
         new_series_result = SedaroSeries.load(file_path)
 
         ref_series_result = new_result.agent(


### PR DESCRIPTION
## Task Link or Description
- Removes dot files from being considered amongst parquet data

## Describe Your Changes
-

## Sibling Branches/MRs
-

## Next Steps?
-

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.8 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
