### PR TITLE
only look in 'blocks', not in its siblings, to find an agent's blocks

### DIFF
--- a/sedaro/src/sedaro/results/simulation_result.py
+++ b/sedaro/src/sedaro/results/simulation_result.py
@@ -29,7 +29,8 @@ class SimulationResult(FromFileAndToFileAreDeprecated):
         self.__meta: Dict = data['meta']
         raw_series = data['series']
         agent_id_name_map = _get_agent_id_name_map(self.__meta)
-        self.__agent_ids, self.__block_structures, self.__column_index = _restructure_data(raw_series, agent_id_name_map, self.__meta)
+        self.__agent_ids, self.__block_structures, self.__column_index = _restructure_data(
+            raw_series, agent_id_name_map, self.__meta)
 
     def __repr__(self) -> str:
         return f'SedaroSimulationResult(branch={self.__branch}, status={self.status})'
@@ -113,7 +114,8 @@ class SimulationResult(FromFileAndToFileAreDeprecated):
             os.makedirs(path)
         except FileExistsError:
             if not (os.path.isdir(path) and any(os.scandir(path))):
-                raise FileExistsError(f"A file or non-empty directory already exists at {path}. Please specify a different path.")
+                raise FileExistsError(
+                    f"A file or non-empty directory already exists at {path}. Please specify a different path.")
         with open(f"{path}/class.json", "w") as fp:
             json.dump({'class': 'SimulationResult'}, fp)
         with open(f"{path}/meta.json", "w") as fp:
@@ -121,7 +123,7 @@ class SimulationResult(FromFileAndToFileAreDeprecated):
         os.mkdir(f"{path}/data")
         for agent in self.__data['series']:
             agent_parquet_path = f"{path}/data/{agent.replace('/', '.')}"
-            df : dd = self.__data['series'][agent]
+            df: dd = self.__data['series'][agent]
             df.to_parquet(agent_parquet_path)
         print(f"Simulation result saved to {path}.")
 

--- a/sedaro/src/sedaro/results/utils.py
+++ b/sedaro/src/sedaro/results/utils.py
@@ -35,15 +35,13 @@ def hfill(char="-", len=HFILL):
 def _element_id_dict(agent_data):
     '''Break out all blocks into a dict where each key is an ID.'''
     out = {}
-    for entry in agent_data.values():
-        if isinstance(entry, dict):
-            for id_, value in entry.items():
-                if 'id' in value:
-                    if id_ in out:
-                        raise ValueError(f"Duplicate ID {id_}")
-                    else:
-                        out[id_] = value
-
+    if 'blocks' in agent_data:
+        for id_, value in agent_data['blocks'].items():
+            if 'id' in value:
+                if id_ in out:
+                    raise ValueError(f"Duplicate ID {id_}")
+                else:
+                    out[id_] = value
     return out
 
 
@@ -84,7 +82,7 @@ def _restructure_data(series, agents, meta):
 
         columns = df.columns.tolist()
         for column in columns:
-            if '/' not in column: # ignore engine variables
+            if '/' not in column:  # ignore engine variables
                 elements = column.split(".")
                 first_element = elements[0]
                 if first_element not in blocks[agent_id]:
@@ -128,7 +126,7 @@ def bsearch(ordered_series, value):
         if ordered_series[mid] == value:
             return mid
         elif ordered_series[mid] > value:
-            return _bsearch(low, mid-1)
+            return _bsearch(low, mid - 1)
         else:
             return _bsearch(mid, high)
     if value < ordered_series[0]:


### PR DESCRIPTION
## Task Link or Description
-

## Describe Your Changes
Fixes the Python client bug reported by Brad. Until now, the Results API has identified an agent's blocks by searching all entries `x` in the agent's structure data such that `type(x) is dict`. There is no need to search anything other than `agent_data['blocks']`. Until now, the formats of the other entries `x` were such that this bug went undetected, but new such entries contained non-iterable values, which caused the crash Brad encountered.

## Sibling Branches/MRs
-

## Next Steps?
-

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.8 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
