### PR TITLE
Persist Dask Dataframe repartitioning in memory

### DIFF
--- a/sedaro/src/sedaro/branches/scenario_branch/download.py
+++ b/sedaro/src/sedaro/branches/scenario_branch/download.py
@@ -100,6 +100,7 @@ class DownloadWorker:
             stream_manager.dataframe = stream_manager.dataframe.repartition(partition_size="100MB") # REF 1
             stream_manager.dataframe = stream_manager.dataframe.reset_index(drop=True)
             stream_manager.filter_columns()
+            stream_manager.dataframe = stream_manager.dataframe.persist()
         for k in self.streams:
             self.streams[k] = self.streams[k].finalize()
 


### PR DESCRIPTION
When we repartition the Dask Dataframe after dataset download for better efficiency, persist these changes so that computations done before save/load get the performance benefit.

Before:

```
Starting...
Downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████[00:37<00:00]
elapsed time: 0.9601459503173828 s # before save/load
Simulation result saved to foo/bar/baz.
elapsed time: 0.14522290229797363 s # after save/load
```

After:
```
Starting...
Downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████[00:42<00:00]
elapsed time: 0.12028908729553223 s # before save/load
Simulation result saved to foo/bar/baz.
elapsed time: 0.13490605354309082 s # after save/load
```
