### PR TITLE
Load only specified Parquet files in Results API

### DIFF
--- a/sedaro/src/sedaro/results/block.py
+++ b/sedaro/src/sedaro/results/block.py
@@ -96,17 +96,20 @@ class SedaroBlockResult(FromFileAndToFileAreDeprecated):
                     f"A file or non-empty directory already exists at {path}. Please specify a different path.")
         with open(f"{path}/class.json", "w") as fp:
             json.dump({'class': 'SedaroBlockResult'}, fp)
+        os.mkdir(f"{path}/data")
+        parquet_files = []
+        for engine in self.__series:
+            engine_parquet_path = f"{path}/data/{(pname := engine.replace('/', '.'))}"
+            parquet_files.append(pname)
+            df: dd = self.__series[engine]
+            df.to_parquet(engine_parquet_path)
         with open(f"{path}/meta.json", "w") as fp:
             json.dump({
                 'structure': self.__structure,
                 'column_index': self.__column_index,
-                'prefix': self.__prefix
+                'prefix': self.__prefix,
+                'parquet_files': parquet_files,
             }, fp)
-        os.mkdir(f"{path}/data")
-        for engine in self.__series:
-            engine_parquet_path = f"{path}/data/{engine.replace('/', '.')}"
-            df: dd = self.__series[engine]
-            df.to_parquet(engine_parquet_path)
         print(f"Block result saved to {path}.")
 
     @classmethod
@@ -122,9 +125,14 @@ class SedaroBlockResult(FromFileAndToFileAreDeprecated):
             column_index = meta['column_index']
             prefix = meta['prefix']
         engines = {}
-        for agent in get_parquets(f"{path}/data/"):
-            df = dd.read_parquet(f"{path}/data/{agent}")
-            engines[agent.replace('.', '/')] = df
+        try:
+            for agent in meta['parquet_files']:
+                df = dd.read_parquet(f"{path}/data/{agent}")
+                engines[agent.replace('.', '/')] = df
+        except KeyError:
+            for agent in get_parquets(f"{path}/data/"):
+                df = dd.read_parquet(f"{path}/data/{agent}")
+                engines[agent.replace('.', '/')] = df
         return cls(structure, engines, column_index, prefix)
 
     def summarize(self) -> None:

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 from pathlib import Path
@@ -97,25 +98,60 @@ def test_save_load():
         file_path = Path(temp_dir) / "sim.bak"
         result.save(file_path)
         # test that .DS_STORE, etc. doesn't interfere with loading
-        os.system(f"touch {temp_dir}/.DS_STORE")
+        os.system(f"touch {file_path}/.DS_STORE")
+        os.system(f"touch {file_path}/data/foobar.parquet")
+        new_result = SimulationResult.load(file_path)
+
+        file_path = Path(temp_dir) / "sim2.bak"
+        result.save(file_path)
+        os.system(f"touch {file_path}/.DS_STORE")
+        with open(f"{file_path}/meta.json", "r") as f:
+            meta = json.load(f)
+        del meta['parquet_files']
+        with open(f"{file_path}/meta.json", "w") as f:
+            json.dump(meta, f)
         new_result = SimulationResult.load(file_path)
 
         file_path = Path(temp_dir) / "agent.bak"
         agent_result = new_result.agent(new_result.templated_agents[0])
         agent_result.save(file_path)
-        os.system(f"touch {temp_dir}/.DS_STORE")
+        os.system(f"touch {file_path}/.DS_STORE")
+        os.system(f"touch {file_path}/data/foobar.parquet")
+        new_agent_result = SedaroAgentResult.load(file_path)
+
+        file_path = Path(temp_dir) / "agent2.bak"
+        agent_result = new_result.agent(new_result.templated_agents[0])
+        agent_result.save(file_path)
+        os.system(f"touch {file_path}/.DS_STORE")
+        with open(f"{file_path}/meta.json", "r") as f:
+            meta = json.load(f)
+        del meta['parquet_files']
+        with open(f"{file_path}/meta.json", "w") as f:
+            json.dump(meta, f)
         new_agent_result = SedaroAgentResult.load(file_path)
 
         file_path = Path(temp_dir) / "block.bak"
         block_result = new_agent_result.block('root')
         block_result.save(file_path)
-        os.system(f"touch {temp_dir}/.DS_STORE")
+        os.system(f"touch {file_path}/.DS_STORE")
+        os.system(f"touch {file_path}/data/foobar.parquet")
+        new_block_result = SedaroBlockResult.load(file_path)
+
+        file_path = Path(temp_dir) / "block2.bak"
+        block_result = new_agent_result.block('root')
+        block_result.save(file_path)
+        os.system(f"touch {file_path}/.DS_STORE")
+        with open(f"{file_path}/meta.json", "r") as f:
+            meta = json.load(f)
+        del meta['parquet_files']
+        with open(f"{file_path}/meta.json", "w") as f:
+            json.dump(meta, f)
         new_block_result = SedaroBlockResult.load(file_path)
 
         file_path = Path(temp_dir) / "series.bak"
         series_result = new_block_result.position.ecef
         series_result.save(file_path)
-        os.system(f"touch {temp_dir}/.DS_STORE")
+        os.system(f"touch {file_path}/.DS_STORE")
         new_series_result = SedaroSeries.load(file_path)
 
         ref_series_result = new_result.agent(


### PR DESCRIPTION
## Task Link or Description
-

## Describe Your Changes
-

## Sibling Branches/MRs
-

## Next Steps?
-

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.8 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
