### PR TITLE
Drop support python 3.8, update typing extensions and dask versions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 - [ ] Necessary new tests added and documentation written
 - [ ] Thorough self-review
 - [ ] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
-- [ ] All tests are passing for python 3.8 - 3.11
+- [ ] All tests are passing for python 3.9 - 3.11
 - [ ] No remaining forbidden code tags (`FIXME`, etc.)
 - [ ] No new lint introduced
 - [ ] Backwards compatibility is understood and any breaking changes have been brought up to the team

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ python3 tests
 Install the python version you want to use if it isn't already installed:
 
 ```zsh
-brew install python@3.7
-brew install python@3.8
 brew install python@3.9
 brew install python@3.10
 ...etc
@@ -50,9 +48,9 @@ python3 -V
 
 - Create and activate virtual environment (first `deactivate` current virtual environment and delete `.venv` directory if already exists):
 
-  - Switch out "3.8" for desired version
+  - Switch out "3.9" for desired version
   ```zsh
-  python3.8 -m venv ./.venv
+  python3.9 -m venv ./.venv
   source .venv/bin/activate
   ```
 

--- a/python_version_manager/__main__.py
+++ b/python_version_manager/__main__.py
@@ -23,7 +23,7 @@ TESTS_PYPI_TEST = 'tt'
 SWITCH_PYPI = 'sp'
 TESTS_PYPI = 'tp'
 
-PY_VERSIONS_TESTS = ['3.8', '3.9', '3.10', '3.11']
+PY_VERSIONS_TESTS = ['3.9', '3.10', '3.11']
 
 SWITCH_INSTR = 'Switch python version, install sedaro from: '
 TEST_INSTR = f'Run tests in python versions {PY_VERSIONS_TESTS} using sedaro from: '

--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -7,8 +7,8 @@ name = "sedaro"
 version = "4.11.36"
 description = "A python client to interact with the Sedaro API."
 readme = "README.md"
-requires-python = ">=3.8"
-classifiers = [ "Programming Language :: Python :: 3.8", "License :: OSI Approved :: GNU General Public License v3 (GPLv3)", "Operating System :: OS Independent", "Topic :: Software Development",]
+requires-python = ">=3.9"
+classifiers = [ "Programming Language :: Python :: 3.9", "License :: OSI Approved :: GNU General Public License v3 (GPLv3)", "Operating System :: OS Independent", "Topic :: Software Development",]
 dependencies = [
   "certifi >= 14.5.14",
   "dask[dataframe] ~= 2023.5",

--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -9,7 +9,25 @@ description = "A python client to interact with the Sedaro API."
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [ "Programming Language :: Python :: 3.8", "License :: OSI Approved :: GNU General Public License v3 (GPLv3)", "Operating System :: OS Independent", "Topic :: Software Development",]
-dependencies = [ "certifi >= 14.5.14", "dask[dataframe] ~= 2023.5", "flatdict ~= 4.0.1", "frozendict ~= 2.3.4", "msgpack ~= 1.0.7", "python-dateutil ~= 2.7", "setuptools >= 21.0.0", "tqdm ~= 4.66.1", "typing_extensions ~= 4.3.0", "urllib3 ~= 1.26.7", "uuid6 ~= 2023.5.2", "pydash >= 5.1.1", "scipy >= 1.10.1", "numpy", "orjson", "pyarrow", "requests",]
+dependencies = [
+  "certifi >= 14.5.14",
+  "dask[dataframe] ~= 2023.5",
+  "flatdict ~= 4.0.1",
+  "frozendict ~= 2.3.4",
+  "msgpack ~= 1.0.7",
+  "python-dateutil ~= 2.7",
+  "setuptools >= 21.0.0",
+  "tqdm ~= 4.66.1",
+  "typing_extensions >= 4.3.0",
+  "urllib3 ~= 1.26.7",
+  "uuid6 ~= 2023.5.2",
+  "pydash >= 5.1.1",
+  "scipy >= 1.10.1",
+  "numpy",
+  "orjson",
+  "pyarrow",
+  "requests",
+]
 [[project.authors]]
 name = "Sedaro"
 email = "support@sedarotech.com"

--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9"
 classifiers = [ "Programming Language :: Python :: 3.9", "License :: OSI Approved :: GNU General Public License v3 (GPLv3)", "Operating System :: OS Independent", "Topic :: Software Development",]
 dependencies = [
   "certifi >= 14.5.14",
-  "dask[dataframe] ~= 2023.5",
+  "dask[dataframe] ~= 2024.5",
   "flatdict ~= 4.0.1",
   "frozendict ~= 2.3.4",
   "msgpack ~= 1.0.7",


### PR DESCRIPTION
## Task Link or Description
- Update python client dependency per [suggestion](https://sedaro.slack.com/archives/C05RL27GC87/p1714746477673079)

## Describe Your Changes
- Make the required version number for `typing_extensions` more flexible
  - Change from `~= 4.3.0` to `>= 4.3.0`
- Drop support python 3.8 and update dask version
  - Python >=3.11.9 didn't work with Dask <= 2024.0, and Dask >= 2023.5.1 doesn't work with python 3.8
  - Added a return early where needed so dask method doesn't receive an empty list
- Some auto-formatting

## Sibling Branches/MRs
- None

## Next Steps?
- None

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.8 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints
- [x] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
