### PR TITLE
Variable length lists as lists, not strings, when accessed from dataframe in Results API

### DIFF
--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -105,10 +105,14 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
 
         if not (self.__has_subseries and not self.__is_singleton_or_vector()):
             if not self.__has_subseries:
-                return self.__series[self.__column_names[0]].compute().tolist()
+                column_name = self.__column_names[0]
+                return values_from_df(self.__series[column_name].compute().tolist(), name=column_name)
             else:
                 computed_columns = {nonprefixed_column_name(
-                    column_name): self.__series[column_name].compute().tolist() for column_name in self.__series.columns}
+                    column_name): values_from_df(
+                        self.__series[column_name].compute().tolist(), name=column_name
+                    ) for column_name in self.__series.columns
+                }
                 vals = []
                 num_indexes = -1
                 for column in computed_columns:

--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Union
 
 from .utils import (HFILL, FromFileAndToFileAreDeprecated, bsearch,
-                    get_column_names, hfill)
+                    get_column_names, hfill, value_from_df, values_from_df)
 
 if TYPE_CHECKING:
     import dask.dataframe as dd
@@ -125,7 +125,7 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
                     ptr.extend(computed_columns[column])
                 rotated_indexes = tuple([num_indexes] + list(range(num_indexes)))
                 import numpy as np
-                return np.transpose(vals, rotated_indexes).tolist()
+                return values_from_df(np.transpose(vals, rotated_indexes).tolist(), name=self.__name)
 
         else:
             return {key: self.__getattr__(key).values for key in self.__column_index}
@@ -162,8 +162,8 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
                 if index < 0:
                     raise_error()
             else:
-                return self.values_interpolant(mjd).tolist()  # casts from nparr(x) to x
-            return self.__series.head(index + 1).tail(1).values[0][0]
+                return value_from_df(self.values_interpolant(mjd).tolist(), name=self.__name)  # casts from nparr(x) to x
+            return value_from_df(self.__series.head(index + 1).tail(1).values[0][0], name=self.__name)
 
     def plot(self, show=True, ylabel=None, elapsed_time=True, height=None, xlim=None, ylim=None, **kwargs):
         self.__plot(show, ylabel, elapsed_time, height, xlim, ylim, **kwargs)

--- a/sedaro/src/sedaro/results/utils.py
+++ b/sedaro/src/sedaro/results/utils.py
@@ -1,3 +1,4 @@
+import json
 import math
 from os import listdir
 from pathlib import Path
@@ -170,6 +171,24 @@ def get_parquets(path: str):
     paths = listdir(path)
     return [parquet for parquet in paths if not parquet.startswith('.')]
 
+VLLS = [
+    'visibleEarthArea',
+    'activeRoutines',
+    'availableTransmitters',
+    'pseudoranges',
+]
+
+def values_from_df(values, name=None):
+    if name in VLLS:
+        return [json.loads(value) for value in values]
+    else:
+        return values
+
+def value_from_df(value, name=None):
+    if name in VLLS:
+        return json.loads(value)
+    else:
+        return value
 
 class FromFileAndToFileAreDeprecated:
     @classmethod

--- a/sedaro/src/sedaro/results/utils.py
+++ b/sedaro/src/sedaro/results/utils.py
@@ -179,13 +179,13 @@ VLLS = [
 ]
 
 def values_from_df(values, name=None):
-    if name in VLLS:
+    if name in VLLS or ('.' in name and name.split('.')[-1] in VLLS):
         return [json.loads(value) for value in values]
     else:
         return values
 
 def value_from_df(value, name=None):
-    if name in VLLS:
+    if name in VLLS or ('.' in name and name.split('.')[-1] in VLLS):
         return json.loads(value)
     else:
         return value

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -329,6 +329,7 @@ def test_series_values():
         'pref.c.baz.1.0': [0, 8, 16, 24, 32, 40],
         'pref.c.baz.1.1': [0, 9, 18, 27, 36, 45],
         'pref.d.a': [0, 10, 20, 30, 40, 50],
+        'pref.visibleEarthArea': [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15], [16, 17, 18]],
     }, npartitions=1)
     df = df.set_index('time')
 
@@ -337,6 +338,7 @@ def test_series_values():
         'b': {},
         'c': {'foo': {}, 'bar': {}, 'baz': {'0': {'0': {}, '1': {}}, '1': {'0': {}, '1': {}}}},
         'd': {'a': {}},
+        'visibleEarthArea': {},
     }
 
     ser = SedaroSeries('pref', df, col_ind, 'pref')
@@ -350,6 +352,7 @@ def test_series_values():
             'baz': [[[0, 0], [0, 0]], [[6, 7], [8, 9]], [[12, 14], [16, 18]], [[18, 21], [24, 27]], [[24, 28], [32, 36]], [[30, 35], [40, 45]]],
         },
         'd': {'a': [0, 10, 20, 30, 40, 50]},
+        'visibleEarthArea': [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15], [16, 17, 18]],
     }
 
     df2 = df[['pref.c.baz.0.0', 'pref.c.baz.0.1', 'pref.c.baz.1.0', 'pref.c.baz.1.1']]


### PR DESCRIPTION
## Task Link or Description
- Resolves https://gitlab.sedaro.com/sedaro-satellite/satellite-app/-/issues/52

## Describe Your Changes
- Ensures that VLL values accessed via DataFrame in the Results API will be provided in their intended form - as lists rather than as strings.

## Sibling Branches/MRs
- None

## Next Steps?
- None

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.9 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints
- [x] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
