### PR TITLE
Allow auth handle authentication when opening a grpc cosim connection

### DIFF
--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
   "grpcio-tools",
   "protobuf",
   "openpyxl",
-  "aiohttp",
 ]
 [[project.authors]]
 name = "Sedaro"

--- a/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
+++ b/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
@@ -788,7 +788,7 @@ class SimulationHandle:
                 # ...
         """
         sedaro = self._sim_client.get_sedaro()
-        api_key = sedaro._api_key
+        headers = sedaro._auth_header()
         host = sedaro._api_host
         grpc_host = grpc_host or sedaro._grpc_host
 
@@ -798,7 +798,7 @@ class SimulationHandle:
 
         cosim_client = CosimClient(
             grpc_host=grpc_host,
-            api_key=api_key,
+            auth_headers=headers,
             address=address,
             job_id=job_id,
             host=host,

--- a/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
+++ b/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
@@ -788,7 +788,6 @@ class SimulationHandle:
                 # ...
         """
         sedaro = self._sim_client.get_sedaro()
-        headers = sedaro._auth_header()
         host = sedaro._api_host
         grpc_host = grpc_host or sedaro._grpc_host
 
@@ -798,11 +797,11 @@ class SimulationHandle:
 
         cosim_client = CosimClient(
             grpc_host=grpc_host,
-            auth_headers=headers,
             address=address,
             job_id=job_id,
             host=host,
             insecure=insecure,
+            sedaro=sedaro,
         )
 
         try:

--- a/sedaro/src/sedaro/grpc_client/cosim_client.py
+++ b/sedaro/src/sedaro/grpc_client/cosim_client.py
@@ -35,9 +35,9 @@ class MetadataClientInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
 
 
 class CosimClient:
-    def __init__(self, grpc_host: str, api_key: str, address: str, job_id: str, host: str, insecure: bool = False):
+    def __init__(self, grpc_host: str, auth_headers: Tuple[str, str], address: str, job_id: str, host: str, insecure: bool = False):
         self.grpc_host = grpc_host
-        self.api_key = api_key
+        self.auth_headers = auth_headers
         self.address = address
         self.job_id = job_id
         self.host = host
@@ -120,7 +120,7 @@ class CosimClient:
         async with aiohttp.ClientSession() as session:
             url = f"{self.host}/simulations/jobs/authorization/{self.job_id}"
             params = {"audience": "SimBed", "permission": "RUN_SIMULATION"}
-            headers = {"X_API_KEY": self.api_key}
+            headers = [self.auth_headers]
 
             try:
                 logging.info(f"Getting auth token from {url}")

--- a/sedaro/src/sedaro/grpc_client/cosim_client.py
+++ b/sedaro/src/sedaro/grpc_client/cosim_client.py
@@ -4,11 +4,9 @@ import itertools
 import json
 import logging
 import os
-import uuid
-from typing import Any, Coroutine, Optional, Tuple
+from typing import Any, Optional, Tuple
 from urllib.parse import urlencode
 
-import aiohttp
 import grpc
 from sedaro.sedaro_api_client import SedaroApiClient
 
@@ -193,13 +191,13 @@ class CosimClient:
         self,
         external_state_id: str,
         agent_id: str,
-        value: Any,
+        values: Tuple,
         timestamp: float = 0.0
     ):
         index = next(self._produce_counter)
         produce_action = cosim_pb2.Produce(
             index=index,
-            value=json.dumps({"payload": serdes(value)})
+            value=json.dumps({"payload": serdes(values)})
         )
         simulation_action = cosim_pb2.SimulationAction(
             cluster_handle_address=self.address,


### PR DESCRIPTION
## Task Link or Description
https://gitlab.sedaro.com/sedaro-satellite/satellite-app/-/issues/742

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints
- [x] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

