### PR TITLE
Results API: better error message when an expected agent is missing

### DIFF
--- a/sedaro/src/sedaro/results/simulation_result.py
+++ b/sedaro/src/sedaro/results/simulation_result.py
@@ -146,7 +146,7 @@ class SimulationResult(FromFileAndToFileAreDeprecated):
             try:
                 agent_id, name = self.__agent_id_from_name(id_or_name), id_or_name
             except ValueError:
-                raise ValueError(f"Agent with `id` or `name` '{id_or_name}' not found in data set.")
+                raise ValueError(f"Agent with `id` or `name` '{id_or_name}' not found in data set. If an expected agent is missing, the simulation may have terminated early.")
         agent_dataframes = {}
         for stream_id in self.__data['series']:
             if stream_id.startswith(agent_id):


### PR DESCRIPTION
## Task Link or Description
- if a simulation terminates very early, an agent may be unexpectedly absent from the data set. This improves the relevant error message to indicate this info.

## Describe Your Changes
-

## Sibling Branches/MRs
-

## Next Steps?
-

## Checklist
- [ ] Necessary new tests added and documentation written
- [ ] Thorough self-review
- [ ] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [ ] All tests are passing for python 3.9 - 3.11
- [ ] No remaining forbidden code tags (`FIXME`, etc.)
- [ ] No new lint introduced
- [ ] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [ ] No unintentional (debug-related) console prints
- [ ] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
