### PR TITLE
fix `datetime_now_utc` function

### DIFF
--- a/sedaro/src/sedaro/modsim.py
+++ b/sedaro/src/sedaro/modsim.py
@@ -14,7 +14,7 @@ REF_DATETIME = datetime.datetime(2024, 3, 21, 0, 27, 23, tzinfo=datetime.timezon
 def datetime_now_utc() -> datetime.datetime:
     '''Python version agnostic way to get the current UTC datetime.'''
     try:
-        return datetime.now(datetime.UTC)
+        return datetime.datetime.now(datetime.UTC)
     except ImportError:
         return datetime.datetime.utcnow() # now deprecated
 

--- a/tests/test_modsim.py
+++ b/tests/test_modsim.py
@@ -24,6 +24,10 @@ def test_time_conversions():
     with pytest.raises(AssertionError, match='Datetime must have a timezone'):
         ms.datetime_to_mjd(datetime.datetime(2024, 3, 20, 0, 27, 23))
 
+
+def test_datetime_now():
+    assert ms.datetime_now_utc() == datetime.datetime.now(datetime.timezone.utc)
+
 def test_read_csv_time_series():
     path = os.path.dirname(os.path.abspath(__file__))
     data = ms.read_csv_time_series(f'{path}/assets/test.csv')
@@ -92,6 +96,7 @@ def test_rotmat2quaternion():
 
 def run_tests():
     test_time_conversions()
+    test_datetime_now()
     test_read_csv_time_series()
     test_read_excel_time_series()
     test_search_time_series()

--- a/tests/test_modsim.py
+++ b/tests/test_modsim.py
@@ -26,7 +26,11 @@ def test_time_conversions():
 
 
 def test_datetime_now():
-    assert ms.datetime_now_utc() == datetime.datetime.now(datetime.timezone.utc)
+    modsim_dt = ms.datetime_now_utc()
+    datetime_dt = datetime.datetime.now(datetime.timezone.utc)
+    assert (datetime_dt - modsim_dt).total_seconds() < 1e-3
+    assert modsim_dt.tzinfo == datetime.timezone.utc
+
 
 def test_read_csv_time_series():
     path = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Task Link or Description
- Closes #104

## Describe Your Changes
- Fixes the `datetime_now_utc` function to call `now` on the `datetime.datetime` object instead of the `datetime` module.
- Adds `test_datetime_now` function to `test_modsim.py`.

## Sibling Branches/MRs
-

## Next Steps?
-

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.9 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints
- [x] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
