### PR TITLE
modsim `data_scale_unit` function and tests

### DIFF
--- a/sedaro/src/sedaro/modsim.py
+++ b/sedaro/src/sedaro/modsim.py
@@ -463,3 +463,26 @@ def unit3(vec: np.ndarray) -> np.ndarray:
     if np.linalg.norm(vec) > EPSILON:
         return vec/np.linalg.norm(vec)
     raise ValueError("Vector cannot be the zero vector.")
+
+
+def data_scale_unit(value: int, bytes: bool = False) -> tuple[float, str]:
+    """
+    Find the appropriate unit to scale the given bit value and return the scale along with the unit string.
+    The input value can be divided by the returned scale to convert it to the returned unit.
+
+    Args:
+        value (float): The value to be scaled.
+        bytes (bool): Whether to convert the value to bytes.
+
+    Returns:
+        tuple: A tuple containing the scale and the unit string.
+    """
+    units = ("", "k", "M", "G", "T", "P")
+    if value == 0:
+        return value, ""
+    value = value if not bytes else value / 8
+    exponent = max(math.floor(math.log10(abs(value)) // 3), 0)
+    scale: int = (10 ** (exponent * 3))
+    scale = scale if not bytes else scale * 8
+    unit = units[exponent]
+    return scale, unit

--- a/sedaro/src/sedaro/modsim.py
+++ b/sedaro/src/sedaro/modsim.py
@@ -481,7 +481,7 @@ def data_scale_unit(value: int, bytes: bool = False) -> tuple[float, str]:
     if value == 0:
         return value, ""
     value = value if not bytes else value / 8
-    exponent = max(math.floor(math.log10(abs(value)) // 3), 0)
+    exponent = min(max(math.floor(math.log10(abs(value)) // 3), 0), len(units) - 1)
     scale: int = (10 ** (exponent * 3))
     scale = scale if not bytes else scale * 8
     unit = units[exponent]

--- a/tests/test_modsim.py
+++ b/tests/test_modsim.py
@@ -112,6 +112,8 @@ test_data_scale_unit_cases = [
     (5e12 * 8, True, (1e12 * 8, "T")),
     (6e15, False, (1e15, "P")),
     (6e15 * 8, True, (1e15 * 8, "P")),
+    (7e16, False, (1e15, "P")),
+    (7e16 * 8, True, (1e15 * 8, "P")),
 ]
 
 @pytest.mark.parametrize("value, bytes, expected", test_data_scale_unit_cases)

--- a/tests/test_modsim.py
+++ b/tests/test_modsim.py
@@ -98,6 +98,26 @@ def test_rotmat2quaternion():
     quat_truth = np.array([quat_truth_raw[1], quat_truth_raw[2], quat_truth_raw[3], quat_truth_raw[0]])
     assert (np.max(np.abs(quat_truth - ms.rotmat2quaternion(rot_mat))) < 1e-5)
 
+test_data_scale_unit_cases = [
+    (0, False, (0, "")),
+    (1, True, (8, "")),
+    (8, True, (8, "")),
+    (2e3, False, (1e3, "k")),
+    (2e3 * 8, True, (1e3 * 8, "k")),
+    (3e6, False, (1e6, "M")),
+    (3e6 * 8, True, (1e6 * 8, "M")),
+    (4e9, False, (1e9, "G")),
+    (4e9 * 8, True, (1e9 * 8, "G")),
+    (5e12, False, (1e12, "T")),
+    (5e12 * 8, True, (1e12 * 8, "T")),
+    (6e15, False, (1e15, "P")),
+    (6e15 * 8, True, (1e15 * 8, "P")),
+]
+
+@pytest.mark.parametrize("value, bytes, expected", test_data_scale_unit_cases)
+def test_data_scale_unit(value: int, bytes: bool, expected: tuple[float, str]):
+    assert ms.data_scale_unit(value, bytes) == expected
+
 def run_tests():
     test_time_conversions()
     test_datetime_now()
@@ -106,3 +126,5 @@ def run_tests():
     test_search_time_series()
     test_vectors2angle()
     test_rotmat2quaternion()
+    for case in test_data_scale_unit_cases:
+        test_data_scale_unit(*case)


### PR DESCRIPTION
## Task Link or Description
- https://github.com/sedaro/modsim-notebooks/pull/46#discussion_r1898821310

## Describe Your Changes
- Add the `data_scale_unit` function and tests to `sedaro.modsim`.

## Sibling Branches/MRs
-

## Next Steps?
-

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.9 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints
- [x] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
