### PR TITLE
Maintain order, but filter out duplicates in get_all

### DIFF
--- a/sedaro/src/sedaro/branches/blocks/block_type.py
+++ b/sedaro/src/sedaro/branches/blocks/block_type.py
@@ -92,7 +92,7 @@ class BlockType:
 
         recurse_get_block_dicts(self.type)
 
-        # maintain order and filter out duplicates
+        # maintain order & filter out duplicates
         return list(dict.fromkeys(res))
 
     def get_all(self) -> List['Block']:

--- a/sedaro/src/sedaro/branches/blocks/block_type.py
+++ b/sedaro/src/sedaro/branches/blocks/block_type.py
@@ -92,7 +92,8 @@ class BlockType:
 
         recurse_get_block_dicts(self.type)
 
-        return res
+        # maintain order and filter out duplicates
+        return list(dict.fromkeys(res))
 
     def get_all(self) -> List['Block']:
         """Gets a `list` of all `Block` instances corresponding to all Sedaro Blocks of the given type in this

--- a/tests/test_crud_and_traversal.py
+++ b/tests/test_crud_and_traversal.py
@@ -2,7 +2,7 @@ import string
 from random import choices
 
 import pytest
-from config import API_KEY, HOST, SIMPLESAT_A_T_ID, SIMPLESAT_SCENARIO_ID
+from config import API_KEY, HOST, SIMPLESAT_A_T_ID, SIMPLESAT_SCENARIO_ID, WILDFIRE_A_T_ID
 
 from sedaro import SedaroApiClient
 from sedaro.branches import AgentTemplateBranch, Branch, ScenarioBranch
@@ -329,6 +329,16 @@ def test_multiblock_crud_with_ref_ids():
         branch.update(delete=[bp.id, bc.id])
 
 
+def test_no_duplicates_in_get_all():
+    sedaro = SedaroApiClient(api_key=API_KEY, host=HOST)
+    vehicle = sedaro.agent_template(WILDFIRE_A_T_ID)
+
+    eDIs = vehicle.ExternalDataInterface.get_all()
+
+    # make sure there are no duplicates even w/ double inheritance
+    assert len(set(eDIs)) == len(eDIs) > 0
+
+
 def run_tests():
     test_get()
     test_keying_into_root_attrs()
@@ -344,3 +354,4 @@ def run_tests():
     test_active_comm_interfaces_tuple()
     test_attitude_solution_error_tuple()
     test_multiblock_crud_with_ref_ids()
+    test_get_all_no_duplicates()


### PR DESCRIPTION
## Task Link or Description
- The `get_all` method returns some Block's twice

![image](https://github.com/user-attachments/assets/9562338f-17b2-48dd-bbe6-b04dedd77ea4)


## Describe Your Changes
- Caused in some cases when there is double inheritance in Block. Fixed by filtering out duplicates after collecting id's of all blocks relevant to query.

## Sibling Branches/MRs
- None

## Next Steps?
- None

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.9 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints
- [x] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
