### PR TITLE
Update get where to work with Blocks or IDs in relationships

### DIFF
--- a/sedaro/src/sedaro/branches/blocks/block_type.py
+++ b/sedaro/src/sedaro/branches/blocks/block_type.py
@@ -118,7 +118,7 @@ class BlockType:
                 Branch
         """
         return [
-            b_c for b_c in self.get_all() if all(getattr(b_c, k) == v for k, v in fields.items())
+            block for block in self.get_all() if all(getattr(block, k) == v for k, v in fields.items())
         ]
 
     def get_first(self):

--- a/sedaro/src/sedaro/branches/blocks/block_type.py
+++ b/sedaro/src/sedaro/branches/blocks/block_type.py
@@ -118,7 +118,8 @@ class BlockType:
                 Branch
         """
         return [
-            block for block in self.get_all() if all(getattr(block, k) == v for k, v in fields.items())
+            block for block in self.get_all()
+            if all(getattr(block, k) == v for k, v in fields.items())
         ]
 
     def get_first(self):

--- a/tests/test_crud_and_traversal.py
+++ b/tests/test_crud_and_traversal.py
@@ -397,3 +397,4 @@ def run_tests():
     test_attitude_solution_error_tuple()
     test_multiblock_crud_with_ref_ids()
     test_no_duplicates_in_get_all()
+    test_get_where_with_relationships()

--- a/tests/test_crud_and_traversal.py
+++ b/tests/test_crud_and_traversal.py
@@ -354,4 +354,4 @@ def run_tests():
     test_active_comm_interfaces_tuple()
     test_attitude_solution_error_tuple()
     test_multiblock_crud_with_ref_ids()
-    test_get_all_no_duplicates()
+    test_no_duplicates_in_get_all()


### PR DESCRIPTION
## Task Link or Description
- https://gitlab.sedaro.com/sedaro-satellite/satellite-app/-/issues/988

## Describe Your Changes
- Update `get_where` to work with Blocks or IDs in relationship fields

## Sibling Branches/MRs
- None

## Next Steps?
- None

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.9 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints
- [x] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
