### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Run tests
         uses: ./.github/actions/test-action
+        env:
+          PYTHONUNBUFFERED: 1
         with:
           python-versions: ${{ matrix.python-version }}
           # pass secrets b/c action can't access them

--- a/sedaro/pyproject.toml
+++ b/sedaro/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9"
 classifiers = [ "Programming Language :: Python :: 3.9", "License :: OSI Approved :: GNU General Public License v3 (GPLv3)", "Operating System :: OS Independent", "Topic :: Software Development",]
 dependencies = [
   "certifi >= 14.5.14",
-  "dask[dataframe, distributed] ~= 2024.5",
+  "dask[dataframe] ~= 2024.5",
   "flatdict ~= 4.0.1",
   "frozendict ~= 2.3.4",
   "msgpack ~= 1.0.7",

--- a/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
+++ b/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
@@ -371,14 +371,7 @@ class Simulation:
         download_managers = [DownloadWorker(
             download_bar, i + 1) for i in range(num_workers)]
         params = {'start': start, 'stop': stop, 'sampleRate': sampleRate}
-        client = None
         if num_workers > 1:
-            # set up Dask distributed scheduler so the workers don't step on each other's toes and deadlock
-            if __name__ == '__main__':
-                from dask.distributed import Client, LocalCluster
-                cluster = LocalCluster(n_workers=num_workers, threads_per_worker=1)
-                client = Client(cluster)
-
             with ThreadPoolExecutor(max_workers=num_workers) as executor:
                 try:
                     exceptions = executor.map(
@@ -409,8 +402,6 @@ class Simulation:
             'static': download_managers[0].finalize_static_data(download_managers[1:]),
             'series': stream_results,
         }
-        if client is not None:
-            client.close()
         return result
 
     def results(

--- a/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
+++ b/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import math
 import signal
 import sys
 import threading
@@ -91,6 +92,7 @@ class Simulation:
         label=None,
         capacity=None,
         seed=None,
+        verbose=False,
         **kwargs,
     ) -> 'SimulationHandle':
         """Starts simulation corresponding to the respective Sedaro Scenario Branch id.
@@ -101,6 +103,7 @@ class Simulation:
             label (str, optional): A label to assign to the simulation job. Defaults to `None`.
             capacity (int, optional): The capacity to allocate to the simulation. Defaults to using the lesser of the Workspace capacity and the number of Agents in the Scenario.
             seed (int, optional): The pseudorandom seed to use for the simulation. Defaults to the Simulation Service's default.
+            verbose (bool, optional): If `True`, periodically print the sim's status to the console while waiting for it to start. Defaults to `False`.
             **kwargs: Additional keyword arguments to pass to the simulation job as part of the HTTP request body.
 
         Returns:
@@ -129,6 +132,8 @@ class Simulation:
             if (handle := handle.status())[STATUS] in PRE_RUN_STATUSES:
                 time.sleep(0.1)
                 t += 0.1
+                if verbose and math.isclose(t % 10.0, 0.0, abs_tol=0.01):
+                    print(f'Current simulation status: {handle[STATUS]}')
             elif handle[STATUS] in BAD_STATUSES:
                 raise SimInitializationError(handle['message'])
             else:

--- a/tests/test_externals.py
+++ b/tests/test_externals.py
@@ -49,21 +49,23 @@ def test_run_externals():
     sim = sedaro.scenario(SIMPLESAT_SCENARIO_ID).simulation
 
     # Start simulation
-    simulation_handle = sim.start(wait=True, verbose=True)
+    simulation_handle = sim.start(wait=True, verbose=True, timeout=600)
     print('- Started simulation')
 
-    __do_test(simulation_handle)
+    try:
+        __do_test(simulation_handle)
 
-    # Test that can communicate after handle refresh
-    simulation_handle.status()
-    __do_test(simulation_handle)
+        # Test that can communicate after handle refresh
+        simulation_handle.status()
+        __do_test(simulation_handle)
 
-    simulation_handle = sim.status()
-    __do_test(simulation_handle)
+        simulation_handle = sim.status()
+        __do_test(simulation_handle)
 
-    # Terminate
-    print('- Terminating...')
-    sim.terminate()
+    finally:
+        # Terminate
+        print('- Terminating...')
+        sim.terminate()
 
 
 def run_tests():

--- a/tests/test_externals.py
+++ b/tests/test_externals.py
@@ -16,7 +16,7 @@ def __do_test(simulation_handle):
     assert tuple() == simulation_handle.produce(
         agent_id, block_id, ([1, 2, 3],))
     assert tuple() == simulation_handle.produce(
-        agent_id, block_id, ([4, 5, 6],), timestamp=59911*2)
+        agent_id, block_id, ([4, 5, 6],), timestamp=59911 * 2)
 
     result = simulation_handle.consume(agent_id, block_id)
     assert type(result) is tuple
@@ -29,7 +29,7 @@ def __do_test(simulation_handle):
     assert len(result) == 1
     assert type(result[0]) is np.ndarray
     assert result[0].shape == (3,)
-    assert json.dumps(result[0].tolist()) == json.dumps([6800.,    0.,    0.])
+    assert json.dumps(result[0].tolist()) == json.dumps([6800., 0., 0.])
 
     result = simulation_handle.consume(agent_id, block_id, time=59911.001)
     assert type(result) is tuple
@@ -49,7 +49,7 @@ def test_run_externals():
     sim = sedaro.scenario(SIMPLESAT_SCENARIO_ID).simulation
 
     # Start simulation
-    simulation_handle = sim.start(wait=True)
+    simulation_handle = sim.start(wait=True, verbose=True)
     print('- Started simulation')
 
     __do_test(simulation_handle)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from time import sleep
 
 import uuid6
 from config import API_KEY, HOST, SUPERDOVE_SCENARIO_ID, WILDFIRE_SCENARIO_ID
@@ -23,6 +24,10 @@ def _make_sure_wildfire_terminated():
         assert results.status == 'TERMINATED'
     except (NoSimResultsError, AssertionError):
         sim.start(wait=True, verbose=True, timeout=600)
+
+        # ensure that the sim runs for a bit before terminating, so that there is guaranteed to be data
+        sleep(20)
+
         sim.terminate()
 
 
@@ -32,7 +37,7 @@ def _make_sure_superdove_done():
         results = sim.results()
         assert results.success
     except (NoSimResultsError, AssertionError):
-        sim.start()
+        sim.start(verbose=True, timeout=600)
         sim.results_poll()
 
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -25,7 +25,7 @@ def _make_sure_wildfire_terminated():
     except (NoSimResultsError, AssertionError):
         sim.start(wait=True, verbose=True, timeout=600)
 
-        # ensure that the sim runs for a bit before terminating, so that there is guaranteed to be data
+        # ensure that the sim runs for a bit before terminating, to ensure that some data is produced
         sleep(20)
 
         sim.terminate()

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -22,7 +22,7 @@ def _make_sure_wildfire_terminated():
         results = sim.results()
         assert results.status == 'TERMINATED'
     except (NoSimResultsError, AssertionError):
-        sim.start(wait=True)
+        sim.start(wait=True, verbose=True, timeout=600)
         sim.terminate()
 
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -79,10 +79,10 @@ def test_start_as_contextmanager():
     sim = sedaro.scenario(SIMPLESAT_SCENARIO_ID).simulation
 
     try:
-        with sim.start(wait=True) as simulation_handle:
+        with sim.start(wait=True, verbose=True, timeout=600) as simulation_handle:
             sim_id = simulation_handle['id']
             assert simulation_handle.status()[STATUS] == RUNNING
-            raise ValueError('Intentional error') # intentionally raise error
+            raise ValueError('Intentional error')  # intentionally raise error
     except ValueError as e:
         if str(e) != 'Intentional error':
             raise

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -36,40 +36,44 @@ def test_run_simulation():
     simulation_handle = sim.start()
     print('- Started simulation')
 
-    _wait_until_passed_pending(simulation_handle)
+    try:
+        _wait_until_passed_pending(simulation_handle)
 
-    # Get status (via default latest)
-    _check_job_status_running(
-        sim.status()
-    )
+        # Get status (via default latest)
+        _check_job_status_running(
+            sim.status()
+        )
 
-    # Get status (via id)
-    _check_job_status_running(
-        sim.status(simulation_handle['id'])
-    )
+        # Get status (via id)
+        _check_job_status_running(
+            sim.status(simulation_handle['id'])
+        )
 
-    # Terminate
-    print('- Terminating...')
-    sim.terminate()
+    finally:
+        # Terminate
+        print('- Terminating...')
+        sim.terminate()
 
     # Test control from handle
     simulation_handle = sim.start()
     print('- Started simulation (via handle)')
 
-    _wait_until_passed_pending(simulation_handle)
+    try:
+        _wait_until_passed_pending(simulation_handle)
 
-    # Get status (via handle)
-    _check_job_status_running(
-        simulation_handle := simulation_handle.status()
-    )
-    # Assert idempotency
-    _check_job_status_running(
-        simulation_handle := simulation_handle.status()
-    )
+        # Get status (via handle)
+        _check_job_status_running(
+            simulation_handle := simulation_handle.status()
+        )
+        # Assert idempotency
+        _check_job_status_running(
+            simulation_handle := simulation_handle.status()
+        )
 
-    # Terminate
-    print('- Terminating (via handle)...')
-    simulation_handle.terminate()
+    finally:
+        # Terminate
+        print('- Terminating (via handle)...')
+        simulation_handle.terminate()
 
     # Test that handle is still useable
     assert simulation_handle.status()[STATUS] == TERMINATED


### PR DESCRIPTION
## Task Link or Description
-

## Describe Your Changes
- Use `PYTHONUNBUFFERED` to immediately print rather than waiting for completion
- Use try/finally to ensure sims are properly terminated even when the test fails before reaching the termination command
- Sleep for a bit between when Wildfire starts running and trying to fetch data from it (will make currently-flaky data fetching tests more robust)
- Add 'verbose mode' to `sim.start(wait=True)` - arg `verbose=True` will print sim's current status at 10-second intervals
- Add 10-minute timeouts to all instances of `sim.start(wait=True)` in the test suite

## Sibling Branches/MRs
-

## Next Steps?
-

## Checklist
- [ ] Necessary new tests added and documentation written
- [ ] Thorough self-review
- [ ] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [ ] All tests are passing for python 3.9 - 3.11
- [ ] No remaining forbidden code tags (`FIXME`, etc.)
- [ ] No new lint introduced
- [ ] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [ ] No unintentional (debug-related) console prints
- [ ] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
