### PR TITLE
Test python versions 3.12 and 3.13 in `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.11', '3.10', '3.9']
+        python-version: ['3.13', '3.12', '3.11', '3.10', '3.9']
       max-parallel: 1
 
     steps:


### PR DESCRIPTION
## Describe Your Changes
- 3.12 and 3.13 were added to `test` but not `publish`. Here I add them to `publish` as well.