### PR TITLE
Improvements to Results API save/load functionality

### DIFF
--- a/sedaro/src/sedaro/results/agent.py
+++ b/sedaro/src/sedaro/results/agent.py
@@ -93,7 +93,7 @@ class SedaroAgentResult(SedaroResultBase):
         return SedaroBlockResult(block_structure, block_streams, self.__stats, self.__column_index[id_],
             prefix, self.stats_to_plot, static_data_for_block)
 
-    def do_save(self, path: Union[str, Path]):
+    def _do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the agent's series data, and returns associated metadata.'''
         parquet_files = self.save_parquets(self.__series, path)
         return {
@@ -107,7 +107,7 @@ class SedaroAgentResult(SedaroResultBase):
         }
 
     @classmethod
-    def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroAgentResult':
+    def _do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroAgentResult':
         '''Load an agent's data from the specified path and return a SedaroAgentResult object.'''
         engines = cls.load_parquets(path, metadata)
         # Build the agent result

--- a/sedaro/src/sedaro/results/agent.py
+++ b/sedaro/src/sedaro/results/agent.py
@@ -112,34 +112,6 @@ class SedaroAgentResult(SedaroResultBase):
             'static': self.__static_data,
         }
 
-    # @classmethod
-    # def load(cls, path: Union[str, Path]):
-    #     '''Load an agent result from the specified path.'''
-    #     import dask.dataframe as dd
-
-    #     with open(f"{path}/class.json", "r") as fp:
-    #         archive_type = json.load(fp)['class']
-    #         if archive_type != 'SedaroAgentResult':
-    #             raise ValueError(f"Archive at {path} is a {archive_type}. Please use {archive_type}.load instead.")
-    #     with open(f"{path}/meta.json", "r") as fp:
-    #         meta = json.load(fp)
-    #         name = meta['name']
-    #         block_structures = meta['block_structures']
-    #         initial_state = meta['initial_state']
-    #         column_index = meta['column_index']
-    #         stats = meta['stats'] if 'stats' in meta else {}
-    #         static_data = meta['static'] if 'static' in meta else {}
-    #     engines = {}
-    #     try:
-    #         for engine in meta['parquet_files']:
-    #             df = dd.read_parquet(f"{path}/data/{engine}")
-    #             engines[engine.replace('.', '/')] = df
-    #     except KeyError:
-    #         for engine in get_parquets(f"{path}/data/"):
-    #             df = dd.read_parquet(f"{path}/data/{engine}")
-    #             engines[engine.replace('.', '/')] = df
-    #     return cls(name, block_structures, engines, column_index, initial_state, stats, static_data=static_data)
-
     @classmethod
     def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroAgentResult':
         '''Load an agent's data from the specified path and return a SedaroAgentResult object.'''

--- a/sedaro/src/sedaro/results/agent.py
+++ b/sedaro/src/sedaro/results/agent.py
@@ -95,13 +95,7 @@ class SedaroAgentResult(SedaroResultBase):
 
     def do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the agent's series data, and returns associated metadata.'''
-        os.mkdir(data_subdir_path := self.data_subdir(path))
-        parquet_files = []
-        for engine in self.__series:
-            engine_parquet_path = f"{data_subdir_path}/{(pq_filename := engine.replace('/', '.'))}"
-            parquet_files.append(pq_filename)
-            df: 'dd' = self.__series[engine]
-            df.to_parquet(engine_parquet_path)
+        parquet_files = self.save_parquets(self.__series, path)
         return {
             'name': self.__name,
             'initial_state': self.__initial_state,

--- a/sedaro/src/sedaro/results/agent.py
+++ b/sedaro/src/sedaro/results/agent.py
@@ -109,18 +109,7 @@ class SedaroAgentResult(SedaroResultBase):
     @classmethod
     def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroAgentResult':
         '''Load an agent's data from the specified path and return a SedaroAgentResult object.'''
-        import dask.dataframe as dd
-        data_subdir_path = cls.data_subdir(path)
-        # Load the data
-        engines = {}
-        try:
-            for engine in metadata['parquet_files']:
-                df = dd.read_parquet(f"{data_subdir_path}/{engine}")
-                engines[engine.replace('.', '/')] = df
-        except KeyError:
-            for engine in get_parquets(data_subdir_path):
-                df = dd.read_parquet(f"{data_subdir_path}/{engine}")
-                engines[engine.replace('.', '/')] = df
+        engines = cls.load_parquets(path, metadata)
         # Build the agent result
         return cls(
             metadata['name'],

--- a/sedaro/src/sedaro/results/agent.py
+++ b/sedaro/src/sedaro/results/agent.py
@@ -93,37 +93,6 @@ class SedaroAgentResult(SedaroResultBase):
         return SedaroBlockResult(block_structure, block_streams, self.__stats, self.__column_index[id_],
             prefix, self.stats_to_plot, static_data_for_block)
 
-    # def save(self, path: Union[str, Path]):
-    #     '''Save the agent result to a directory with the specified path.'''
-    #     import dask.dataframe as dd
-
-    #     try:
-    #         os.makedirs(path)
-    #     except FileExistsError:
-    #         if not (os.path.isdir(path) and any(os.scandir(path))):
-    #             raise FileExistsError(
-    #                 f"A file or non-empty directory already exists at {path}. Please specify a different path.")
-    #     with open(f"{path}/class.json", "w") as fp:
-    #         json.dump({'class': 'SedaroAgentResult'}, fp)
-    #     os.mkdir(f"{path}/data")
-    #     parquet_files = []
-    #     for engine in self.__series:
-    #         engine_parquet_path = f"{path}/data/{(pname := engine.replace('/', '.'))}"
-    #         parquet_files.append(pname)
-    #         df: dd = self.__series[engine]
-    #         df.to_parquet(engine_parquet_path)
-    #     with open(f"{path}/meta.json", "w") as fp:
-    #         json.dump({
-    #             'name': self.__name,
-    #             'initial_state': self.__initial_state,
-    #             'block_structures': self.__block_structures,
-    #             'column_index': self.__column_index,
-    #             'parquet_files': parquet_files,
-    #             'stats': self.__stats,
-    #             'static': self.__static_data,
-    #         }, fp)
-    #     print(f"Agent result saved to {path}.")
-
     def do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the agent's series data, and returns associated metadata.'''
         os.mkdir(data_subdir_path := self.data_subdir(path))

--- a/sedaro/src/sedaro/results/agent.py
+++ b/sedaro/src/sedaro/results/agent.py
@@ -112,33 +112,59 @@ class SedaroAgentResult(SedaroResultBase):
             'static': self.__static_data,
         }
 
-    @classmethod
-    def load(cls, path: Union[str, Path]):
-        '''Load an agent result from the specified path.'''
-        import dask.dataframe as dd
+    # @classmethod
+    # def load(cls, path: Union[str, Path]):
+    #     '''Load an agent result from the specified path.'''
+    #     import dask.dataframe as dd
 
-        with open(f"{path}/class.json", "r") as fp:
-            archive_type = json.load(fp)['class']
-            if archive_type != 'SedaroAgentResult':
-                raise ValueError(f"Archive at {path} is a {archive_type}. Please use {archive_type}.load instead.")
-        with open(f"{path}/meta.json", "r") as fp:
-            meta = json.load(fp)
-            name = meta['name']
-            block_structures = meta['block_structures']
-            initial_state = meta['initial_state']
-            column_index = meta['column_index']
-            stats = meta['stats'] if 'stats' in meta else {}
-            static_data = meta['static'] if 'static' in meta else {}
+    #     with open(f"{path}/class.json", "r") as fp:
+    #         archive_type = json.load(fp)['class']
+    #         if archive_type != 'SedaroAgentResult':
+    #             raise ValueError(f"Archive at {path} is a {archive_type}. Please use {archive_type}.load instead.")
+    #     with open(f"{path}/meta.json", "r") as fp:
+    #         meta = json.load(fp)
+    #         name = meta['name']
+    #         block_structures = meta['block_structures']
+    #         initial_state = meta['initial_state']
+    #         column_index = meta['column_index']
+    #         stats = meta['stats'] if 'stats' in meta else {}
+    #         static_data = meta['static'] if 'static' in meta else {}
+    #     engines = {}
+    #     try:
+    #         for engine in meta['parquet_files']:
+    #             df = dd.read_parquet(f"{path}/data/{engine}")
+    #             engines[engine.replace('.', '/')] = df
+    #     except KeyError:
+    #         for engine in get_parquets(f"{path}/data/"):
+    #             df = dd.read_parquet(f"{path}/data/{engine}")
+    #             engines[engine.replace('.', '/')] = df
+    #     return cls(name, block_structures, engines, column_index, initial_state, stats, static_data=static_data)
+
+    @classmethod
+    def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroAgentResult':
+        '''Load an agent's data from the specified path and return a SedaroAgentResult object.'''
+        import dask.dataframe as dd
+        data_subdir_path = cls.data_subdir(path)
+        # Load the data
         engines = {}
         try:
-            for engine in meta['parquet_files']:
-                df = dd.read_parquet(f"{path}/data/{engine}")
+            for engine in metadata['parquet_files']:
+                df = dd.read_parquet(f"{data_subdir_path}/{engine}")
                 engines[engine.replace('.', '/')] = df
         except KeyError:
-            for engine in get_parquets(f"{path}/data/"):
-                df = dd.read_parquet(f"{path}/data/{engine}")
+            for engine in get_parquets(data_subdir_path):
+                df = dd.read_parquet(f"{data_subdir_path}/{engine}")
                 engines[engine.replace('.', '/')] = df
-        return cls(name, block_structures, engines, column_index, initial_state, stats, static_data=static_data)
+        # Build the agent result
+        return cls(
+            metadata['name'],
+            metadata['block_structures'],
+            engines,
+            metadata['column_index'],
+            metadata['initial_state'],
+            metadata['stats'] if 'stats' in metadata else {},
+            static_data=metadata['static'] if 'static' in metadata else {},
+        )
 
     def summarize(self) -> None:
         '''Summarize these results in the console.'''

--- a/sedaro/src/sedaro/results/block.py
+++ b/sedaro/src/sedaro/results/block.py
@@ -122,34 +122,6 @@ class SedaroBlockResult(SedaroResultBase):
         '''Query a particular variable by name.'''
         return self.__getattr__(name)
 
-    # def save(self, path: Union[str, Path]):
-    #     '''Save the block result to a directory with the specified path.'''
-    #     try:
-    #         os.makedirs(path)
-    #     except FileExistsError:
-    #         if not (os.path.isdir(path) and any(os.scandir(path))):
-    #             raise FileExistsError(
-    #                 f"A file or non-empty directory already exists at {path}. Please specify a different path.")
-    #     with open(f"{path}/class.json", "w") as fp:
-    #         json.dump({'class': 'SedaroBlockResult'}, fp)
-    #     os.mkdir(f"{path}/data")
-    #     parquet_files = []
-    #     for engine in self.__series:
-    #         engine_parquet_path = f"{path}/data/{(pname := engine.replace('/', '.'))}"
-    #         parquet_files.append(pname)
-    #         df: 'dd' = self.__series[engine]
-    #         df.to_parquet(engine_parquet_path)
-    #     with open(f"{path}/meta.json", "w") as fp:
-    #         json.dump({
-    #             'structure': self.__structure,
-    #             'column_index': self.__column_index,
-    #             'prefix': self.__prefix,
-    #             'parquet_files': parquet_files,
-    #             'stats': self.__stats,
-    #             'static': self.__static_data,
-    #         }, fp)
-    #     print(f"Block result saved to {path}.")
-
     def do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the block's series data, and returns associated metadata.'''
         os.mkdir(data_subdir_path := self.data_subdir(path))

--- a/sedaro/src/sedaro/results/block.py
+++ b/sedaro/src/sedaro/results/block.py
@@ -140,33 +140,6 @@ class SedaroBlockResult(SedaroResultBase):
             'static': self.__static_data,
         }
 
-    # @classmethod
-    # def load(cls, path: Union[str, Path]):
-    #     '''Load a block result from the specified path.'''
-    #     import dask.dataframe as dd
-
-    #     with open(f"{path}/class.json", "r") as fp:
-    #         archive_type = json.load(fp)['class']
-    #         if archive_type != 'SedaroBlockResult':
-    #             raise ValueError(f"Archive at {path} is a {archive_type}. Please use {archive_type}.load instead.")
-    #     with open(f"{path}/meta.json", "r") as fp:
-    #         meta = json.load(fp)
-    #         structure = meta['structure']
-    #         column_index = meta['column_index']
-    #         prefix = meta['prefix']
-    #         stats = meta['stats'] if 'stats' in meta else {}
-    #         static_data = meta['static'] if 'static' in meta else {}
-    #     engines = {}
-    #     try:
-    #         for agent in meta['parquet_files']:
-    #             df = dd.read_parquet(f"{path}/data/{agent}")
-    #             engines[agent.replace('.', '/')] = df
-    #     except KeyError:
-    #         for agent in get_parquets(f"{path}/data/"):
-    #             df = dd.read_parquet(f"{path}/data/{agent}")
-    #             engines[agent.replace('.', '/')] = df
-    #     return cls(structure, engines, stats, column_index, prefix, static_data=static_data)
-
     @classmethod
     def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroBlockResult':
         '''Load a block's data from the specified path and return a SedaroBlockResult object.'''

--- a/sedaro/src/sedaro/results/block.py
+++ b/sedaro/src/sedaro/results/block.py
@@ -122,7 +122,7 @@ class SedaroBlockResult(SedaroResultBase):
         '''Query a particular variable by name.'''
         return self.__getattr__(name)
 
-    def do_save(self, path: Union[str, Path]):
+    def _do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the block's series data, and returns associated metadata.'''
         parquet_files = self.save_parquets(self.__series, path)
         return {
@@ -135,7 +135,7 @@ class SedaroBlockResult(SedaroResultBase):
         }
 
     @classmethod
-    def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroBlockResult':
+    def _do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroBlockResult':
         '''Load a block's data from the specified path and return a SedaroBlockResult object.'''
         engines = cls.load_parquets(path, metadata)
         # build the block result

--- a/sedaro/src/sedaro/results/block.py
+++ b/sedaro/src/sedaro/results/block.py
@@ -137,18 +137,7 @@ class SedaroBlockResult(SedaroResultBase):
     @classmethod
     def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroBlockResult':
         '''Load a block's data from the specified path and return a SedaroBlockResult object.'''
-        import dask.dataframe as dd
-        subdir_path = cls.data_subdir(path)
-        # Load the data
-        engines = {}
-        try:
-            for agent in metadata['parquet_files']:
-                df = dd.read_parquet(f"{subdir_path}/{agent}")
-                engines[agent.replace('.', '/')] = df
-        except KeyError:
-            for agent in get_parquets(f"{subdir_path}/"):
-                df = dd.read_parquet(f"{subdir_path}/{agent}")
-                engines[agent.replace('.', '/')] = df
+        engines = cls.load_parquets(path, metadata)
         # build the block result
         return cls(
             metadata['structure'],

--- a/sedaro/src/sedaro/results/block.py
+++ b/sedaro/src/sedaro/results/block.py
@@ -124,13 +124,7 @@ class SedaroBlockResult(SedaroResultBase):
 
     def do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the block's series data, and returns associated metadata.'''
-        os.mkdir(data_subdir_path := self.data_subdir(path))
-        parquet_files = []
-        for engine in self.__series:
-            engine_parquet_path = f"{data_subdir_path}/{(pq_filename := engine.replace('/', '.'))}"
-            parquet_files.append(pq_filename)
-            df: 'dd' = self.__series[engine]
-            df.to_parquet(engine_parquet_path)
+        parquet_files = self.save_parquets(self.__series, path)
         return {
             'structure': self.__structure,
             'column_index': self.__column_index,

--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -283,7 +283,7 @@ class SedaroSeries(SedaroResultBase):
             raise ValueError(
                 "The data type of this series does not support plotting or the keyword arguments passed were unrecognized.")
 
-    def do_save(self, path: Union[str, Path]):
+    def _do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the series data, and returns associated metadata.'''
         self.__series.to_parquet(f"{path}/{PQ_FILENAME_FOR_DISK}")
         return {
@@ -295,7 +295,7 @@ class SedaroSeries(SedaroResultBase):
         }
 
     @classmethod
-    def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroSeries':
+    def _do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroSeries':
         '''Load a series's data from the specified path and return a SedaroSeries object.'''
         import dask.dataframe as dd
         data = dd.read_parquet(f"{path}/{PQ_FILENAME_FOR_DISK}")

--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -294,25 +294,6 @@ class SedaroSeries(SedaroResultBase):
             'block_name': self.__block_name,
         }
 
-    # @classmethod
-    # def load(cls, path: Union[str, Path]):
-    #     '''Load a series result from the specified path.'''
-    #     import dask.dataframe as dd
-
-    #     with open(f"{path}/class.json", "r") as fp:
-    #         archive_type = json.load(fp)['class']
-    #         if archive_type != 'SedaroSeries':
-    #             raise ValueError(f"Archive at {path} is a {archive_type}. Please use {archive_type}.load instead.")
-    #     with open(f"{path}/meta.json", "r") as fp:
-    #         meta = json.load(fp)
-    #         name = meta['name']
-    #         column_index = meta['column_index']
-    #         prefix = meta['prefix']
-    #         stats = meta['stats'] if 'stats' in meta else {}
-    #         block_name = meta['block_name'] if 'block_name' in meta else None
-    #     data = dd.read_parquet(f"{path}/data.parquet")
-    #     return cls(name, data, stats, column_index, prefix, block_name=block_name)
-
     @classmethod
     def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroSeries':
         '''Load a series's data from the specified path and return a SedaroSeries object.'''

--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -283,27 +283,6 @@ class SedaroSeries(SedaroResultBase):
             raise ValueError(
                 "The data type of this series does not support plotting or the keyword arguments passed were unrecognized.")
 
-    # def save(self, path: Union[str, Path]):
-    #     '''Save the series result to a directory with the specified path.'''
-    #     try:
-    #         os.makedirs(path)
-    #     except FileExistsError:
-    #         if not (os.path.isdir(path) and any(os.scandir(path))):
-    #             raise FileExistsError(
-    #                 f"A file or non-empty directory already exists at {path}. Please specify a different path.")
-    #     with open(f"{path}/class.json", "w") as fp:
-    #         json.dump({'class': 'SedaroSeries'}, fp)
-    #     with open(f"{path}/meta.json", "w") as fp:
-    #         json.dump({
-    #             'name': self.__name,
-    #             'column_index': self.__column_index,
-    #             'prefix': self.__prefix,
-    #             'stats': self.__initial_stats,
-    #             'block_name': self.__block_name,
-    #         }, fp)
-    #     self.__series.to_parquet(f"{path}/data.parquet")
-    #     print(f"Series result saved to {path}.")
-
     def do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the series data, and returns associated metadata.'''
         self.__series.to_parquet(f"{path}/{PQ_FILENAME_FOR_DISK}")

--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -294,24 +294,38 @@ class SedaroSeries(SedaroResultBase):
             'block_name': self.__block_name,
         }
 
-    @classmethod
-    def load(cls, path: Union[str, Path]):
-        '''Load a series result from the specified path.'''
-        import dask.dataframe as dd
+    # @classmethod
+    # def load(cls, path: Union[str, Path]):
+    #     '''Load a series result from the specified path.'''
+    #     import dask.dataframe as dd
 
-        with open(f"{path}/class.json", "r") as fp:
-            archive_type = json.load(fp)['class']
-            if archive_type != 'SedaroSeries':
-                raise ValueError(f"Archive at {path} is a {archive_type}. Please use {archive_type}.load instead.")
-        with open(f"{path}/meta.json", "r") as fp:
-            meta = json.load(fp)
-            name = meta['name']
-            column_index = meta['column_index']
-            prefix = meta['prefix']
-            stats = meta['stats'] if 'stats' in meta else {}
-            block_name = meta['block_name'] if 'block_name' in meta else None
-        data = dd.read_parquet(f"{path}/data.parquet")
-        return cls(name, data, stats, column_index, prefix, block_name=block_name)
+    #     with open(f"{path}/class.json", "r") as fp:
+    #         archive_type = json.load(fp)['class']
+    #         if archive_type != 'SedaroSeries':
+    #             raise ValueError(f"Archive at {path} is a {archive_type}. Please use {archive_type}.load instead.")
+    #     with open(f"{path}/meta.json", "r") as fp:
+    #         meta = json.load(fp)
+    #         name = meta['name']
+    #         column_index = meta['column_index']
+    #         prefix = meta['prefix']
+    #         stats = meta['stats'] if 'stats' in meta else {}
+    #         block_name = meta['block_name'] if 'block_name' in meta else None
+    #     data = dd.read_parquet(f"{path}/data.parquet")
+    #     return cls(name, data, stats, column_index, prefix, block_name=block_name)
+
+    @classmethod
+    def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SedaroSeries':
+        '''Load a series's data from the specified path and return a SedaroSeries object.'''
+        import dask.dataframe as dd
+        data = dd.read_parquet(f"{path}/{PQ_FILENAME_FOR_DISK}")
+        return cls(
+            metadata['name'],
+            data,
+            metadata['stats'] if 'stats' in metadata else {},
+            metadata['column_index'],
+            metadata['prefix'],
+            block_name=metadata['block_name'] if 'block_name' in metadata else None,
+        )
 
     def summarize(self):
         hfill()

--- a/sedaro/src/sedaro/results/series.py
+++ b/sedaro/src/sedaro/results/series.py
@@ -5,13 +5,14 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
 
-from .utils import (HFILL, FromFileAndToFileAreDeprecated, bsearch,
-                    get_column_names, hfill, value_from_df, values_from_df)
+from .utils import HFILL, SedaroResultBase, bsearch, get_column_names, hfill, value_from_df, values_from_df
 
 if TYPE_CHECKING:
     import dask.dataframe as dd
 
-class SedaroSeries(FromFileAndToFileAreDeprecated):
+PQ_FILENAME_FOR_DISK = 'data.parquet'
+
+class SedaroSeries(SedaroResultBase):
 
     def __init__(self, name, data, stats, column_index, prefix, stats_to_plot: list = None, block_name: str = None):
         '''Initialize a new time series.
@@ -127,7 +128,7 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
                 computed_columns = {nonprefixed_column_name(
                     column_name): values_from_df(
                         self.__series[column_name].compute().tolist(), name=column_name
-                    ) for column_name in self.__series.columns
+                ) for column_name in self.__series.columns
                 }
                 vals = []
                 num_indexes = -1
@@ -209,10 +210,14 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
                     if show:
                         for box in self.stats_to_plot:
                             plt.plot([box['pos'], box['pos']], [box['min'], box['max']], color='black', linewidth=1.5)
-                            plt.plot([box['pos'] - 0.3, box['pos'] + 0.3], [box['min'], box['min']], color='black', linewidth=1.5)
-                            plt.plot([box['pos'] - 0.3, box['pos'] + 0.3], [box['max'], box['max']], color='black', linewidth=1.5)
-                            plt.plot([box['pos'] - 0.3, box['pos'] + 0.3], [box['avg'], box['avg']], color='#2D56A0', linestyle='dotted', linewidth=1.5)
-                        plt.xticks([box['pos'] for box in self.stats_to_plot], [box['label'] for box in self.stats_to_plot], rotation=15)
+                            plt.plot([box['pos'] - 0.3, box['pos'] + 0.3],
+                                     [box['min'], box['min']], color='black', linewidth=1.5)
+                            plt.plot([box['pos'] - 0.3, box['pos'] + 0.3],
+                                     [box['max'], box['max']], color='black', linewidth=1.5)
+                            plt.plot([box['pos'] - 0.3, box['pos'] + 0.3], [box['avg'], box['avg']],
+                                     color='#2D56A0', linestyle='dotted', linewidth=1.5)
+                        plt.xticks([box['pos'] for box in self.stats_to_plot], [box['label']
+                                   for box in self.stats_to_plot], rotation=15)
                         plt.tight_layout()
                         plt.show()
                         self.stats_to_plot.clear()
@@ -241,7 +246,8 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
                 if index < 0:
                     raise_error()
             else:
-                return value_from_df(self.values_interpolant(mjd).tolist(), name=self.__name)  # casts from nparr(x) to x
+                # casts from nparr(x) to x
+                return value_from_df(self.values_interpolant(mjd).tolist(), name=self.__name)
             return value_from_df(self.__series.head(index + 1).tail(1).values[0][0], name=self.__name)
 
     def plot(self, show=True, ylabel=None, elapsed_time=True, height=None, xlim=None, ylim=None, **kwargs):
@@ -277,26 +283,37 @@ class SedaroSeries(FromFileAndToFileAreDeprecated):
             raise ValueError(
                 "The data type of this series does not support plotting or the keyword arguments passed were unrecognized.")
 
-    def save(self, path: Union[str, Path]):
-        '''Save the series result to a directory with the specified path.'''
-        try:
-            os.makedirs(path)
-        except FileExistsError:
-            if not (os.path.isdir(path) and any(os.scandir(path))):
-                raise FileExistsError(
-                    f"A file or non-empty directory already exists at {path}. Please specify a different path.")
-        with open(f"{path}/class.json", "w") as fp:
-            json.dump({'class': 'SedaroSeries'}, fp)
-        with open(f"{path}/meta.json", "w") as fp:
-            json.dump({
-                'name': self.__name,
-                'column_index': self.__column_index,
-                'prefix': self.__prefix,
-                'stats': self.__initial_stats,
-                'block_name': self.__block_name,
-            }, fp)
-        self.__series.to_parquet(f"{path}/data.parquet")
-        print(f"Series result saved to {path}.")
+    # def save(self, path: Union[str, Path]):
+    #     '''Save the series result to a directory with the specified path.'''
+    #     try:
+    #         os.makedirs(path)
+    #     except FileExistsError:
+    #         if not (os.path.isdir(path) and any(os.scandir(path))):
+    #             raise FileExistsError(
+    #                 f"A file or non-empty directory already exists at {path}. Please specify a different path.")
+    #     with open(f"{path}/class.json", "w") as fp:
+    #         json.dump({'class': 'SedaroSeries'}, fp)
+    #     with open(f"{path}/meta.json", "w") as fp:
+    #         json.dump({
+    #             'name': self.__name,
+    #             'column_index': self.__column_index,
+    #             'prefix': self.__prefix,
+    #             'stats': self.__initial_stats,
+    #             'block_name': self.__block_name,
+    #         }, fp)
+    #     self.__series.to_parquet(f"{path}/data.parquet")
+    #     print(f"Series result saved to {path}.")
+
+    def do_save(self, path: Union[str, Path]):
+        '''Called by base class's `save` method. Saves the series data, and returns associated metadata.'''
+        self.__series.to_parquet(f"{path}/{PQ_FILENAME_FOR_DISK}")
+        return {
+            'name': self.__name,
+            'column_index': self.__column_index,
+            'prefix': self.__prefix,
+            'stats': self.__initial_stats,
+            'block_name': self.__block_name,
+        }
 
     @classmethod
     def load(cls, path: Union[str, Path]):

--- a/sedaro/src/sedaro/results/simulation_result.py
+++ b/sedaro/src/sedaro/results/simulation_result.py
@@ -1,23 +1,23 @@
 import datetime as dt
 import json
 import os
-from pathlib import Path
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Union
 
-from ..settings import STATUS, SUCCEEDED
 from ..branches.scenario_branch.utils import _get_stats_for_sim_id
+from ..settings import STATUS, SUCCEEDED
 from .agent import SedaroAgentResult
-from .utils import (HFILL, STATUS_ICON_MAP, FromFileAndToFileAreDeprecated,
-                    _block_type_in_supers, _get_agent_id_name_map,
+from .utils import (HFILL, STATUS_ICON_MAP, SedaroResultBase, _block_type_in_supers, _get_agent_id_name_map,
                     _restructure_data, get_parquets, hfill)
 
 if TYPE_CHECKING:
     import dask.dataframe as dd
+
     from ..sedaro_api_client import SedaroApiClient
 
 
-class SimulationResult(FromFileAndToFileAreDeprecated):
+class SimulationResult(SedaroResultBase):
 
     def __init__(self, simulation: dict, data: dict, _sedaro: 'SedaroApiClient' = None, stats_fetched: bool = False):
         '''Initialize a new Simulation Result using methods on the `simulation` property of a `ScenarioBranch`.
@@ -35,7 +35,8 @@ class SimulationResult(FromFileAndToFileAreDeprecated):
         self.__branch = simulation['branch']
         self.__data = data
         self.__meta: dict = data['meta']
-        self.__stats_fetched = ('stats_fetched' in data and data['meta']['stats_fetched']) or ('stats' in data and data['stats'])
+        self.__stats_fetched = ('stats_fetched' in data and data['meta']['stats_fetched']) or (
+            'stats' in data and data['stats'])
         self.__stats = data['stats'] if 'stats' in data else {}
         self.__static_data: dict = data['static'] if 'static' in data else {}
         self.stats_to_plot = []
@@ -147,7 +148,8 @@ class SimulationResult(FromFileAndToFileAreDeprecated):
             try:
                 agent_id, name = self.__agent_id_from_name(id_or_name), id_or_name
             except ValueError:
-                raise ValueError(f"Agent with `id` or `name` '{id_or_name}' not found in data set. If an expected agent is missing, the simulation may have terminated early.")
+                raise ValueError(
+                    f"Agent with `id` or `name` '{id_or_name}' not found in data set. If an expected agent is missing, the simulation may have terminated early.")
         agent_dataframes = {}
         for stream_id in self.__data['series']:
             if stream_id.startswith(agent_id):
@@ -167,27 +169,44 @@ class SimulationResult(FromFileAndToFileAreDeprecated):
             static_data=filtered_static_data,
         )
 
-    def save(self, path: Union[str, Path]):
-        '''Save the simulation result to a directory with the specified path.'''
-        try:
-            os.makedirs(path)
-        except FileExistsError:
-            if not (os.path.isdir(path) and any(os.scandir(path))):
-                raise FileExistsError(
-                    f"A file or non-empty directory already exists at {path}. Please specify a different path.")
-        with open(f"{path}/class.json", "w") as fp:
-            json.dump({'class': 'SimulationResult'}, fp)
-        os.mkdir(f"{path}/data")
+    # def save(self, path: Union[str, Path]):
+    #     '''Save the simulation result to a directory with the specified path.'''
+    #     try:
+    #         os.makedirs(path)
+    #     except FileExistsError:
+    #         if not (os.path.isdir(path) and any(os.scandir(path))):
+    #             raise FileExistsError(
+    #                 f"A file or non-empty directory already exists at {path}. Please specify a different path.")
+    #     with open(f"{path}/class.json", "w") as fp:
+    #         json.dump({'class': 'SimulationResult'}, fp)
+    #     os.mkdir(f"{path}/data")
+    #     parquet_files = []
+    #     for agent in self.__data['series']:
+    #         agent_parquet_path = f"{path}/data/{(pname := agent.replace('/', '.'))}"
+    #         parquet_files.append(pname)
+    #         df: 'dd' = self.__data['series'][agent]
+    #         df.to_parquet(agent_parquet_path)
+    #     with open(f"{path}/meta.json", "w") as fp:
+    #         json.dump({'meta': self.__data['meta'], 'simulation': self.__simulation,
+    #                   'stats': self.__stats, 'static': self.__static_data, 'parquet_files': parquet_files}, fp)
+    #     print(f"Simulation result saved to {path}.")
+
+    def do_save(self, path: Union[str, Path]):
+        '''Called by base class's `save` method. Saves the simulation result's series data, and returns associated metadata.'''
+        os.mkdir(data_subdir_path := self.data_subdir(path))
         parquet_files = []
         for agent in self.__data['series']:
-            agent_parquet_path = f"{path}/data/{(pname := agent.replace('/', '.'))}"
-            parquet_files.append(pname)
+            agent_parquet_path = f"{data_subdir_path}/{(pq_filename := agent.replace('/', '.'))}"
+            parquet_files.append(pq_filename)
             df: 'dd' = self.__data['series'][agent]
             df.to_parquet(agent_parquet_path)
-        with open(f"{path}/meta.json", "w") as fp:
-            json.dump({'meta': self.__data['meta'], 'simulation': self.__simulation,
-                      'stats': self.__stats, 'static': self.__static_data, 'parquet_files': parquet_files}, fp)
-        print(f"Simulation result saved to {path}.")
+        return {
+            'meta': self.__data['meta'],
+            'simulation': self.__simulation,
+            'stats': self.__stats,
+            'static': self.__static_data,
+            'parquet_files': parquet_files,
+        }
 
     @classmethod
     def load(cls, path: Union[str, Path]):

--- a/sedaro/src/sedaro/results/simulation_result.py
+++ b/sedaro/src/sedaro/results/simulation_result.py
@@ -183,24 +183,13 @@ class SimulationResult(SedaroResultBase):
     @classmethod
     def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SimulationResult':
         '''Load a simulation result's data from the specified path and return a SimulationResult object.'''
-        data = {}
-        data['meta'] = metadata['meta']
-        data['stats'] = metadata['stats'] if 'stats' in metadata else {}
-        data['static'] = metadata['static'] if 'static' in metadata else {}
-        data['series'] = {}
-        simulation = metadata['simulation']
-
-        import dask.dataframe as dd
-        data_subdir_path = cls.data_subdir(path)
-        try:
-            for agent in metadata['parquet_files']:
-                df = dd.read_parquet(f"{data_subdir_path}/{agent}")
-                data['series'][agent.replace('.', '/')] = df
-        except KeyError:
-            for agent in get_parquets(f"{data_subdir_path}/"):
-                df = dd.read_parquet(f"{data_subdir_path}/{agent}")
-                data['series'][agent.replace('.', '/')] = df
-        return cls(simulation, data)
+        data = {
+            'meta': metadata['meta'],
+            'stats': metadata['stats'] if 'stats' in metadata else {},
+            'static': metadata['static'] if 'static' in metadata else {},
+            'series': cls.load_parquets(path, metadata),
+        }
+        return cls(metadata['simulation'], data)
 
     def summarize(self) -> None:
         '''Summarize these results in the console.'''

--- a/sedaro/src/sedaro/results/simulation_result.py
+++ b/sedaro/src/sedaro/results/simulation_result.py
@@ -171,13 +171,7 @@ class SimulationResult(SedaroResultBase):
 
     def do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the simulation result's series data, and returns associated metadata.'''
-        os.mkdir(data_subdir_path := self.data_subdir(path))
-        parquet_files = []
-        for agent in self.__data['series']:
-            agent_parquet_path = f"{data_subdir_path}/{(pq_filename := agent.replace('/', '.'))}"
-            parquet_files.append(pq_filename)
-            df: 'dd' = self.__data['series'][agent]
-            df.to_parquet(agent_parquet_path)
+        parquet_files = self.save_parquets(self.__data['series'], path)
         return {
             'meta': self.__data['meta'],
             'simulation': self.__simulation,

--- a/sedaro/src/sedaro/results/simulation_result.py
+++ b/sedaro/src/sedaro/results/simulation_result.py
@@ -186,32 +186,6 @@ class SimulationResult(SedaroResultBase):
             'parquet_files': parquet_files,
         }
 
-    # @classmethod
-    # def load(cls, path: Union[str, Path]):
-    #     '''Load a simulation result from the specified path.'''
-    #     import dask.dataframe as dd
-    #     with open(f"{path}/class.json", "r") as fp:
-    #         archive_type = json.load(fp)['class']
-    #         if archive_type != 'SimulationResult':
-    #             raise ValueError(f"Archive at {path} is a {archive_type}. Please use {archive_type}.load instead.")
-    #     data = {}
-    #     with open(f"{path}/meta.json", "r") as fp:
-    #         contents = json.load(fp)
-    #         simulation = contents['simulation']
-    #         data['meta'] = contents['meta']
-    #         data['stats'] = contents['stats'] if 'stats' in contents else {}
-    #         data['static'] = contents['static'] if 'static' in contents else {}
-    #     data['series'] = {}
-    #     try:
-    #         for agent in contents['parquet_files']:
-    #             df = dd.read_parquet(f"{path}/data/{agent}")
-    #             data['series'][agent.replace('.', '/')] = df
-    #     except KeyError:
-    #         for agent in get_parquets(f"{path}/data/"):
-    #             df = dd.read_parquet(f"{path}/data/{agent}")
-    #             data['series'][agent.replace('.', '/')] = df
-    #     return cls(simulation, data)
-
     @classmethod
     def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SimulationResult':
         '''Load a simulation result's data from the specified path and return a SimulationResult object.'''

--- a/sedaro/src/sedaro/results/simulation_result.py
+++ b/sedaro/src/sedaro/results/simulation_result.py
@@ -169,7 +169,7 @@ class SimulationResult(SedaroResultBase):
             static_data=filtered_static_data,
         )
 
-    def do_save(self, path: Union[str, Path]):
+    def _do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the simulation result's series data, and returns associated metadata.'''
         parquet_files = self.save_parquets(self.__data['series'], path)
         return {
@@ -181,7 +181,7 @@ class SimulationResult(SedaroResultBase):
         }
 
     @classmethod
-    def do_load(cls, path: Union[str, Path], metadata: dict) -> 'SimulationResult':
+    def _do_load(cls, path: Union[str, Path], metadata: dict) -> 'SimulationResult':
         '''Load a simulation result's data from the specified path and return a SimulationResult object.'''
         data = {
             'meta': metadata['meta'],

--- a/sedaro/src/sedaro/results/simulation_result.py
+++ b/sedaro/src/sedaro/results/simulation_result.py
@@ -169,28 +169,6 @@ class SimulationResult(SedaroResultBase):
             static_data=filtered_static_data,
         )
 
-    # def save(self, path: Union[str, Path]):
-    #     '''Save the simulation result to a directory with the specified path.'''
-    #     try:
-    #         os.makedirs(path)
-    #     except FileExistsError:
-    #         if not (os.path.isdir(path) and any(os.scandir(path))):
-    #             raise FileExistsError(
-    #                 f"A file or non-empty directory already exists at {path}. Please specify a different path.")
-    #     with open(f"{path}/class.json", "w") as fp:
-    #         json.dump({'class': 'SimulationResult'}, fp)
-    #     os.mkdir(f"{path}/data")
-    #     parquet_files = []
-    #     for agent in self.__data['series']:
-    #         agent_parquet_path = f"{path}/data/{(pname := agent.replace('/', '.'))}"
-    #         parquet_files.append(pname)
-    #         df: 'dd' = self.__data['series'][agent]
-    #         df.to_parquet(agent_parquet_path)
-    #     with open(f"{path}/meta.json", "w") as fp:
-    #         json.dump({'meta': self.__data['meta'], 'simulation': self.__simulation,
-    #                   'stats': self.__stats, 'static': self.__static_data, 'parquet_files': parquet_files}, fp)
-    #     print(f"Simulation result saved to {path}.")
-
     def do_save(self, path: Union[str, Path]):
         '''Called by base class's `save` method. Saves the simulation result's series data, and returns associated metadata.'''
         os.mkdir(data_subdir_path := self.data_subdir(path))

--- a/sedaro/src/sedaro/results/utils.py
+++ b/sedaro/src/sedaro/results/utils.py
@@ -383,13 +383,13 @@ class SedaroResultBase(ABC):
                     f"A file or non-empty directory already exists at {path}. Please specify a different path.")
         with open(f"{path}/class.json", "w") as fp:
             json.dump({'class': self.__class__.__name__}, fp)
-        metadata_to_save = self.do_save(path)
+        metadata_to_save = self._do_save(path)
         with open(f"{path}/meta.json", "w") as fp:
             json.dump(metadata_to_save, fp)
         print(f"{self.__class__.__name__} saved to {path}.")
 
     @abstractmethod
-    def do_save(self, path: Union[str, Path]) -> dict:
+    def _do_save(self, path: Union[str, Path]) -> dict:
         '''Save the data to the specified path. Return a metadata dict to be saved alongside it.'''
         pass
 
@@ -402,11 +402,11 @@ class SedaroResultBase(ABC):
                 raise ValueError(f"Archive at {path} is a {archive_type}. Please use {archive_type}.load instead.")
         with open(f"{path}/meta.json", "r") as fp:
             metadata_dict = json.load(fp)
-        return cls.do_load(path, metadata_dict)
+        return cls._do_load(path, metadata_dict)
 
     @classmethod
     @abstractmethod
-    def do_load(cls: type[T], path: Union[str, Path], metadata_dict: dict) -> T:
+    def _do_load(cls: type[T], path: Union[str, Path], metadata_dict: dict) -> T:
         '''Given the metadata dict and the path from which to load data, load the data and return an instance of the class.'''
         pass
 


### PR DESCRIPTION
## Task Link or Description
- https://gitlab.sedaro.com/sedaro-satellite/satellite-app/-/issues/1119

## Describe Your Changes
- Consolidates save/load code into a single module for single-source-of-truth (previously the code was fully duplicated across the 4 subclasses in question)
- When saving a DataFrame to Parquet (which is done via pyarrow) fails due to pyarrow failing to properly infer the schema of the DataFrame (pyarrow has much stricter typing requirements than DataFrame and doesn't play well with certain columns), it looks at the information in the well-structured error message that pyarrow raises. It uses this information to write an explicit schema for the troublesome columns, and passes this as an argument to the save-as-parquet method of DataFrame, allowing it to pass.

## Sibling Branches/MRs
- N/A

## Next Steps?
- Very excited for SvV2 due in large part to problems like this one

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.9 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints
- [x] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
