### PR TITLE
Improved robustness for data fetching

### DIFF
--- a/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
+++ b/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
@@ -264,7 +264,9 @@ class Simulation:
                 raw_response = fetcher.get(request_url)
                 if raw_response.status == 500:
                     # retry on 500 error
-                    self.dmlog(download_manager, f"Received 500 error from {request_url}. Retrying...")
+                    self.dmlog(download_manager,
+                        f"Attempt #{attempt+1}/{max_retries}: received 500 error from {request_url}. Retrying...")
+                    time.sleep(1.5 ** attempt)
                     continue
                 elif raw_response.status != 200:
                     error_response = raw_response.parse()

--- a/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
+++ b/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
@@ -283,33 +283,6 @@ class Simulation:
                 reason=f"Failed to successfully fetch data at {request_url} after {max_retries} attempts."
             )
 
-        # self.dmlog(download_manager, f"Calling URL: {url}")
-        # response = fast_fetcher.get(url)
-        # self.dmlog(download_manager, f"Got response from {url} -- status: {response.status}. Parsing response...")
-        # _response = None
-        # has_nonempty_ctoken = False
-        # try:
-        #     _response = response.parse()
-        #     self.dmlog(download_manager, f"Parsed response from {url}")
-        #     if response.status != 200:
-        #         raise Exception()
-        #     else:
-        #         download_manager.ingest(_response['series'])
-        #         download_manager.add_metadata(_response['meta'])
-        #         if 'continuationToken' in _response['meta'] and _response['meta']['continuationToken'] is not None:
-        #             has_nonempty_ctoken = True
-        #             ctoken = _response['meta']['continuationToken']
-        #         if 'stats' in _response:
-        #             download_manager.update_stats(_response['stats'])
-        #         if 'derived' in _response:
-        #             if 'series' in _response['derived']:
-        #                 download_manager.ingest_derived(_response['derived']['series'])
-        #             if 'static' in _response['derived']:
-        #                 download_manager.update_static_data(_response['derived']['static'])
-        # except Exception as e:
-        #     reason = _response['error']['message'] if _response and 'error' in _response else 'An unknown error occurred.'
-        #     raise SedaroApiException(status=response.status, reason=reason)
-
         # fetch and process initial page
         has_nonempty_ctoken = False
         page = get_and_parse_page_with_retry(fast_fetcher, url, download_manager)
@@ -346,33 +319,6 @@ class Simulation:
                     ctoken = page['meta']['continuationToken']
                 else:
                     has_nonempty_ctoken = False
-                # request_url = f'/data/{id}?&continuationToken={ctoken}'
-                # self.dmlog(download_manager, f"Calling URL: {request_url}")
-                # page = fast_fetcher.get(request_url)
-                # self.dmlog(download_manager,
-                #            f"Got response from {request_url} -- status: {page.status}. Parsing response...")
-                # _page = page.parse()
-                # self.dmlog(download_manager, f"Parsed response from {request_url}")
-                # download_manager.ingest(_page['series'])
-                # download_manager.update_metadata(_page['meta'])
-                # try:
-                #     if 'stats' in _page:
-                #         download_manager.update_stats(_page['stats'])
-                #     if 'derived' in _page:
-                #         if 'series' in _page['derived']:
-                #             download_manager.ingest_derived(_page['derived']['series'])
-                #         if 'static' in _page['derived']:
-                #             download_manager.update_static_data(_page['derived']['static'])
-                #     if 'continuationToken' in _page['meta'] and _page['meta']['continuationToken'] is not None:
-                #         has_nonempty_ctoken = True
-                #         ctoken = _page['meta']['continuationToken']
-                #     else:
-                #         has_nonempty_ctoken = False
-                #     if page.status != 200:
-                #         raise Exception()
-                # except Exception as e:
-                #     reason = _page['error']['message'] if _page and 'error' in _page else 'An unknown error occurred.'
-                #     raise SedaroApiException(status=page.status, reason=reason)
 
     def __downloadInParallel(self, sim_id, streams, params, download_manager: DownloadWorker, usesStreamTokens):
         try:

--- a/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
+++ b/sedaro/src/sedaro/branches/scenario_branch/sim_client.py
@@ -308,41 +308,6 @@ class Simulation:
             ctoken = process_parsed_page(page, download_manager)
             is_first_page = False
 
-        # page = get_and_parse_page_with_retry(fast_fetcher, url, download_manager)
-        # download_manager.ingest(page['series'])
-        # download_manager.update_metadata(page['meta'])
-        # if 'continuationToken' in page['meta'] and page['meta']['continuationToken'] is not None:
-        #     has_nonempty_ctoken = True
-        #     ctoken = page['meta']['continuationToken']
-        # if 'stats' in page:
-        #     download_manager.update_stats(page['stats'])
-        # if 'derived' in page:
-        #     if 'series' in page['derived']:
-        #         download_manager.ingest_derived(page['derived']['series'])
-        #     if 'static' in page['derived']:
-        #         download_manager.update_static_data(page['derived']['static'])
-
-        # if has_nonempty_ctoken:  # need to fetch more pages
-        #     while has_nonempty_ctoken:
-        #         # fetch page
-        #         next_page_url = f'/data/{id}?&continuationToken={ctoken}'
-        #         page = get_and_parse_page_with_retry(fast_fetcher, next_page_url, download_manager)
-        #         download_manager.ingest(page['series'])
-        #         download_manager.update_metadata(page['meta'])
-        #         if 'stats' in page:
-        #             download_manager.update_stats(page['stats'])
-        #         if 'derived' in page:
-        #             if 'series' in page['derived']:
-        #                 download_manager.ingest_derived(page['derived']['series'])
-        #             if 'static' in page['derived']:
-        #                 download_manager.update_static_data(page['derived']['static'])
-        #         # check for continuation token
-        #         if 'continuationToken' in page['meta'] and page['meta']['continuationToken'] is not None:
-        #             has_nonempty_ctoken = True
-        #             ctoken = page['meta']['continuationToken']
-        #         else:
-        #             has_nonempty_ctoken = False
-
     def __downloadInParallel(self, sim_id, streams, params, download_manager: DownloadWorker, usesStreamTokens):
         try:
             start = params['start']


### PR DESCRIPTION
## Task Link or Description
- Related to #1103 on GitLab: https://gitlab.sedaro.com/sedaro-satellite/satellite-app/-/issues/1103

## Describe Your Changes
- retries up to 5 times upon getting a 500 error when attempting to fetch a page of data
- consolidates fetch code in general into a cleaner, more modular approach
- fixes a minor bug in the DownloadWorker internals

Tested by running fetches from alpha via this code continuously for several hours with no issues. Multiple times, watching the logs I saw the 500 response be returned and it successfully retry a fetch of that page and then continuing on.

## Sibling Branches/MRs
-

## Next Steps?
-

## Checklist
- [x] Necessary new tests added and documentation written
- [x] Thorough self-review
- [x] If merging to `release-x.y.z`, confirm stability with `release-x.y.z` branches across all other project repositories
- [x] All tests are passing for python 3.9 - 3.11
- [x] No remaining forbidden code tags (`FIXME`, etc.)
- [x] No new lint introduced
- [x] Backwards compatibility is understood and any breaking changes have been brought up to the team
- [x] No unintentional (debug-related) console prints
- [x] Delay imports or use `TYPE_CHECKING` imports for big dependencies, such as `dask.dataframe`, `pandas`, `scipy`, `matplotlib`, `numpy`, etc.

Reminder to switch from "Create pull request" to "Create draft pull request" until ready.
